### PR TITLE
Fix GHC linker errors when linking with external libraries

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -44,7 +44,7 @@ class Submission < ActiveRecord::Base
     end
     if language == 'Haskell'
       source_file = 'program.hs'
-      compiler = '/usr/bin/ghc'
+      compiler = '/usr/bin/ghc --make'
     end
 
     File.open(source_file, 'w') { |f| f.write(source) }


### PR DESCRIPTION
Right now, using anything that isn't in the Haskell base library (i.e. any data structure that isn't a linked list) results in cryptic linker errors. This is very mildly annoying.

It seems GHC doesn't find automatically chase dependencies by default. So it compiles the code against those libraries just fine&mdash;but the linker doesn't get any of it and throws a hissy fit. It's kind of like with GCC, where you have to use the `-l` option to tell it which libraries to link.

Fortunately, giving it the `--make` option seems to straighten it out, which is what this pull request does.

See http://www.haskell.org/pipermail/glasgow-haskell-users/2006-August/010788.html for an explanation.
