### PR TITLE
Update GCC

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -53,7 +53,7 @@ class Language < ActiveRecord::Base
 
   def self.submission_options
     latest = LanguageGroup.where(identifier: %w[c++ c python haskell java ruby j]).pluck(:current_language_id)
-    old = Language.where(identifier: %w[c++03 python2]).pluck(:id)
+    old = Language.where(identifier: %w[c++11 c++14 c99 python2]).pluck(:id)
     languages = Language.where(:id => latest).order(:identifier) + Language.where(:id => old).order(:identifier)
     Hash[languages.map{ |language| ["#{language.group.name} (#{language.name})", language.id] }]
   end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -55,7 +55,7 @@ class Language < ActiveRecord::Base
     latest = LanguageGroup.where(identifier: %w[c++ c python haskell java ruby j]).pluck(:current_language_id)
     old = Language.where(identifier: %w[c++11 c++14 c99 python2]).pluck(:id)
     languages = Language.where(:id => latest).order(:identifier) + Language.where(:id => old).order(:identifier)
-    Hash[languages.map{ |language| ["#{language.group.name} (#{language.name})", language.id] }]
+    Hash[languages.map{ |language| ["#{language.name}", language.id] }]
   end
 
   def self.infer(ext)

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -7,22 +7,28 @@ c++:
   :lexer: c++
   :compiled: yes
   :interpreted: no
-  :current: c++11
+  :current: c++17
   :extension: .cpp
   :source_filename: program
   :exe_extension: .exe
   :processes: 1
   :variants:
-    c++03:
-      :name: "C++03"
+    c++03:  # depreciated
+      :name: "C++03 (GCC 9)"
       :compiler: /usr/bin/g++
       :compiler_command: "%{compiler} -std=gnu++03 -O2 -o %{output} %{source} -lm"
-#      upgrade: c++11 # submissions will be upgraded if possible, if support is removed, it will be force-upgraded
-#      note: probably will never happen for this particular example... (or at least not for the next 10 years)
     c++11:
-      :name: "C++11"
+      :name: "C++11 (GCC 9)"
       :compiler: /usr/bin/g++
       :compiler_command: "%{compiler} -std=gnu++11 -O2 -o %{output} %{source} -lm"
+    c++14:  # Changes since C++11: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1319r0.html
+      :name: "C++14 (GCC 9)"
+      :compiler: /usr/bin/g++
+      :compiler_command: "%{compiler} -std=gnu++14 -O2 -o %{output} %{source} -lm"
+    c++17:  # Changes since C++14: https://isocpp.org/files/papers/p0636r0.html
+      :name: "C++17 (GCC 9)"
+      :compiler: /usr/bin/g++
+      :compiler_command: "%{compiler} -std=gnu++17 -O2 -o %{output} %{source} -lm"
 c:
   :name: C
   :lexer: c
@@ -34,10 +40,15 @@ c:
   :exe_extension: .exe
   :processes: 1
   :variants:
-    c99:
-      :name: C99
+    c99: # depreciated
+      :name: C99 (GCC 9)
       :compiler: /usr/bin/gcc
       :compiler_command: '%{compiler} -std=gnu99 -O2 -o %{output} %{source} -lm'
+    c11:  # Changes since c99: https://en.wikipedia.org/wiki/C11_(C_standard_revision)
+      :name: C11 (GCC 9)
+      :compiler: /usr/bin/gcc
+      :compiler_command: '%{compiler} -std=gnu11 -O2 -o %{output} %{source} -lm'
+
 java:
   :name: Java
   :lexer: java

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -14,23 +14,23 @@ c++:
   :processes: 1
   :variants:
     c++03:  # depreciated
-      :name: "C++03 (GCC 9)"
+      :name: "C++03"
       :compiler: /usr/bin/g++
       :compiler_command: "%{compiler} -std=gnu++03 -O2 -o %{output} %{source} -lm"
     c++11:
-      :name: "C++11 (GCC 9)"
+      :name: "C++11"
       :compiler: /usr/bin/g++
       :compiler_command: "%{compiler} -std=gnu++11 -O2 -o %{output} %{source} -lm"
     c++14:  # Changes since C++11: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1319r0.html
-      :name: "C++14 (GCC 9)"
+      :name: "C++14"
       :compiler: /usr/bin/g++
       :compiler_command: "%{compiler} -std=gnu++14 -O2 -o %{output} %{source} -lm"
     c++17:  # Changes since C++14: https://isocpp.org/files/papers/p0636r0.html
-      :name: "C++17 (GCC 9)"
+      :name: "C++17"
       :compiler: /usr/bin/g++
       :compiler_command: "%{compiler} -std=gnu++17 -O2 -o %{output} %{source} -lm"
 c:
-  :name: C
+  :name: "C"
   :lexer: c
   :compiled: yes
   :interpreted: no
@@ -41,11 +41,11 @@ c:
   :processes: 1
   :variants:
     c99: # depreciated
-      :name: C99 (GCC 9)
+      :name: C99
       :compiler: /usr/bin/gcc
       :compiler_command: '%{compiler} -std=gnu99 -O2 -o %{output} %{source} -lm'
     c11:  # Changes since c99: https://en.wikipedia.org/wiki/C11_(C_standard_revision)
-      :name: C11 (GCC 9)
+      :name: C11
       :compiler: /usr/bin/gcc
       :compiler_command: '%{compiler} -std=gnu11 -O2 -o %{output} %{source} -lm'
 

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -13,7 +13,7 @@ c++:
   :exe_extension: .exe
   :processes: 1
   :variants:
-    c++03:  # depreciated
+    c++03:  # deprecated
       :name: "C++03"
       :compiler: /usr/bin/g++
       :compiler_command: "%{compiler} -std=gnu++03 -O2 -o %{output} %{source} -lm"
@@ -40,7 +40,7 @@ c:
   :exe_extension: .exe
   :processes: 1
   :variants:
-    c99: # depreciated
+    c99: # deprecated
       :name: C99
       :compiler: /usr/bin/gcc
       :compiler_command: '%{compiler} -std=gnu99 -O2 -o %{output} %{source} -lm'

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -140,25 +140,25 @@ if [ ! -f "$ISOLATE_ROOT/usr/bin/cint.rb" ] ; then
   $cmd
 fi
 
-# gcc 4.9.3 on Precise (will not be needed when we use trusty tahr)
+# gcc 9
 echo "$chroot_cmd add-apt-repository ppa:ubuntu-toolchain-r/test -y"
 chroot "$ISOLATE_ROOT" add-apt-repository ppa:ubuntu-toolchain-r/test -y
 
 echo "$chroot_cmd apt-get update"
 chroot "$ISOLATE_ROOT" apt-get update
 
-echo "$chroot_cmd apt-get install gcc-4.9"
-chroot "$ISOLATE_ROOT" apt-get install gcc-4.9
+echo "$chroot_cmd apt-get install gcc-9"
+chroot "$ISOLATE_ROOT" apt-get install gcc-9
 
-echo "$chroot_cmd apt-get install g++-4.9"
-chroot "$ISOLATE_ROOT" apt-get install g++-4.9
+echo "$chroot_cmd apt-get install g++-9"
+chroot "$ISOLATE_ROOT" apt-get install g++-9
 
-echo "$chroot_cmd update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 75"
-chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 75
+echo "$chroot_cmd update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 75"
+chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 75
 
-echo "$chroot_cmd update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 75"
-chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 75
-# gcc 4.9.3 done
+echo "$chroot_cmd update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75"
+chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75
+# gcc 9 done
 
 # let user know that chroot installs are finished
 


### PR DESCRIPTION
Replacing #39 and #42 since we can't yet merge changes in master to the deployed branch.

Update GCC from 4 to 9 and add

- GNU++14 (C++14)
- GNU++17 (C++17)
- GNU11 (C11)

Deprecate

- GNU++03 (C++03)
- GNU99 (C99)

These languages will no longer be available to select from, but the server will still support their compilation so that legacy code may be rejudged and we don't have to remove things from the database.

Install process:
_Originally posted by @tom93 in https://github.com/NZOI/nztrain/pull/39#issuecomment-554689957_

```
chroot ...
apt-get update
apt-get install gcc-9 g++-9
update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 75
update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75
update-alternatives --remove gcc /usr/bin/gcc-4.9
update-alternatives --remove g++ /usr/bin/g++-4.9
apt-get remove gcc-4.9 g++-4.9
apt-get autoremove
```