### PR TITLE
Update python

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -53,7 +53,7 @@ class Language < ActiveRecord::Base
 
   def self.submission_options
     latest = LanguageGroup.where(identifier: %w[c++ c python haskell java ruby j]).pluck(:current_language_id)
-    old = Language.where(identifier: %w[c++11 c++14 c99 python2]).pluck(:id)
+    old = Language.where(identifier: %w[c++11 c++14 c99]).pluck(:id)
     languages = Language.where(:id => latest).order(:identifier) + Language.where(:id => old).order(:identifier)
     Hash[languages.map{ |language| ["#{language.name}", language.id] }]
   end

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -99,12 +99,12 @@ python:
   :interpreter_command: '%{interpreter} %{source}'
   :compiler_command: '%{interpreter} -m py_compile %{source}'
   :variants:
-    python2:  # depreciated - in late 2019 support for the Python 2 language ended
+    python2:  # deprecated - in late 2019 support for the Python 2 language ended
       :name: "Python 2.7"
-      :interpreter: /usr/bin/python
-    python3.4:  # depreciated
+      :interpreter: /usr/bin/python2
+    python3.4:  # deprecated
       :name: "Python 3.4"
-      :interpreter: /usr/bin/python3.8  # since 3.8 is backwards compatable, not point installing another version
+      :interpreter: /usr/bin/python3.4
     python3.8:
       :name: "Python 3.8"
       :interpreter: /usr/bin/python3.8

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -92,19 +92,23 @@ python:
   :lexer: python
   :compiled: no
   :interpreted: yes
-  :current: python3.4
+  :current: python3.8
   :extension: .py
   :source_filename: program
   :processes: 1
   :interpreter_command: '%{interpreter} %{source}'
   :compiler_command: '%{interpreter} -m py_compile %{source}'
   :variants:
-    python2:
+    python2:  # depreciated - in late 2019 support for the Python 2 language ended
       :name: "Python 2.7"
       :interpreter: /usr/bin/python
-    python3.4:
+    python3.4:  # depreciated
       :name: "Python 3.4"
-      :interpreter: /usr/bin/python3.4
+      :interpreter: /usr/bin/python3.8  # since 3.8 is backwards compatable, not point installing another version
+    python3.8:
+      :name: "Python 3.8"
+      :interpreter: /usr/bin/python3.8
+
 ruby:
   :name: Ruby
   :lexer: ruby

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -74,10 +74,6 @@ chroot "$ISOLATE_ROOT" apt-get install wget
 echo "$chroot_install software-properties-common"
 chroot "$ISOLATE_ROOT" apt-get install software-properties-common # provides add-apt-repository
 
-# only for <= 12.04
-# echo "$chroot_install python-software-properties"
-# chroot "$ISOLATE_ROOT" apt-get install python-software-properties # provides add-apt-repository
-
 echo "$chroot_install build-essential"
 chroot "$ISOLATE_ROOT" apt-get install build-essential # C/C++ (g++, gcc)
 
@@ -102,9 +98,18 @@ chroot "$ISOLATE_ROOT" apt-get install openjdk-11-jdk # Java
 [ -z "$TRAVIS" ] && { # if not in Travis-CI
 
   echo "$chroot_install python3.8"
+  
   # if on older OS version
-  # sudo add-apt-repository ppa:deadsnakes/ppa
-  # sudo apt update
+  if [! chroot "$ISOLATE_ROOT" apt-cache show python3.4 &>/dev/null] || 
+     [! chroot "$ISOLATE_ROOT" apt-cache show python3.8 &>/dev/null]; then
+    echo "$chroot_install add-apt-repository ppa:deadsnakes/ppa"
+    chroot "$ISOLATE_ROOT" add-apt-repository ppa:deadsnakes/ppa
+    echo "$chroot_install apt update"
+    chroot "$ISOLATE_ROOT" apt update
+  fi
+  echo "$chroot_install apt-get install python3.4"
+  chroot "$ISOLATE_ROOT" apt-get install python3.4 # Python 3.4
+  echo "$chroot_install apt-get install python3.8"
   chroot "$ISOLATE_ROOT" apt-get install python3.8 # Python 3.8
 
   echo "$chroot_install ruby2.2"

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -54,8 +54,8 @@ mount -o bind /proc "$ISOLATE_ROOT/proc"
 
 [ -z "$TRAVIS" ] && { # if not in Travis-CI
   # python ppa
-  echo "$chroot_cmd add-apt-repository ppa:fkrull/deadsnakes -y"
-  chroot "$ISOLATE_ROOT" add-apt-repository ppa:fkrull/deadsnakes -y
+  # echo "$chroot_cmd add-apt-repository ppa:fkrull/deadsnakes -y"
+  # chroot "$ISOLATE_ROOT" add-apt-repository ppa:fkrull/deadsnakes -y
 
   # ruby ppa
   echo "$chroot_cmd add-apt-repository ppa:brightbox/ruby-ng -y"
@@ -75,8 +75,8 @@ echo "$chroot_install software-properties-common"
 chroot "$ISOLATE_ROOT" apt-get install software-properties-common # provides add-apt-repository
 
 # only for <= 12.04
-echo "$chroot_install python-software-properties"
-chroot "$ISOLATE_ROOT" apt-get install python-software-properties # provides add-apt-repository
+# echo "$chroot_install python-software-properties"
+# chroot "$ISOLATE_ROOT" apt-get install python-software-properties # provides add-apt-repository
 
 echo "$chroot_install build-essential"
 chroot "$ISOLATE_ROOT" apt-get install build-essential # C/C++ (g++, gcc)
@@ -101,8 +101,11 @@ chroot "$ISOLATE_ROOT" apt-get install openjdk-11-jdk # Java
 
 [ -z "$TRAVIS" ] && { # if not in Travis-CI
 
-  echo "$chroot_install python3.4"
-  chroot "$ISOLATE_ROOT" apt-get install python3.4 # Python 3.4
+  echo "$chroot_install python3.8"
+  # if on older OS version
+  # sudo add-apt-repository ppa:deadsnakes/ppa
+  # sudo apt update
+  chroot "$ISOLATE_ROOT" apt-get install python3.8 # Python 3.8
 
   echo "$chroot_install ruby2.2"
   chroot "$ISOLATE_ROOT" apt-get install ruby2.2


### PR DESCRIPTION
Update to Python 3.8 and deprecate

- Python 3.4 - Don't make this available as a submission option.
- Python 2 - Support was discontinued for Python 2 last year, we should do the same.

It is possible that we might be able to use the Python 3.8 interpreter for Python 3.4 code https://www.python.org/dev/peps/pep-0606/. The breaking changes are mostly in the C API, only affecting 3rd party libs, which we don't use.

Sever commands:
```
sudo add-apt-repository ppa:deadsnakes/ppa
sudo apt update
sudo apt install python3.8
```