### PR TITLE
Add JavaScript

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -58,7 +58,7 @@ class Language < ActiveRecord::Base
 
   # for the selection dropdown
   def self.grouped_submission_options
-    current = ["c++", "c", "python", "java", "haskell", "ruby", "j"]  # language group identifiers, order is preserved
+    current = ["c++", "c", "python", "java", "javascript", "haskell", "ruby", "j"]  # language group identifiers, order is preserved
     other = ["c++14", "c++11", "c99"]  # language identifiers, ordered by language name
     current_langs = LanguageGroup.where(:identifier => current).preload(:current_language).map(&:current_language)
     current_options = current_langs.sort_by { |lang| current.index(lang.group.identifier) }.map { |lang| [lang.name, lang.id] }

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -138,3 +138,17 @@ j:
     j8:
       :name: "J 8.0.3"
       :interpreter: /usr/bin/ijconsole-8.0.3
+javascript:
+  :name: JavaScript
+  :lexer: javascript
+  :compiled: no
+  :interpreted: yes
+  :current: v8_8
+  :extension: .js
+  :source_filename: program
+  :interpreter_command: '%{interpreter} %{source}'
+  :variants:
+    v8_8:
+      :name: "JavaScript (V8 8.1)"
+      :interpreter: /usr/bin/d8
+      :processes: 9

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -150,5 +150,5 @@ javascript:
   :variants:
     v8_8:
       :name: "JavaScript (V8 8.1)"
-      :interpreter: /usr/bin/d8
+      :interpreter: /usr/local/bin/d8
       :processes: 9

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -171,7 +171,7 @@ echo "$chroot_cmd update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 
 chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75
 # gcc 9 done
 
-[ -z "$TRAVIS" ] && { # if not in Travis-CI
+[ -z "$TRAVIS" ] && bash script/confirm.bash 'Install JavaScript V8 (submissions in V8 will fail without this!)' && {
   # JavaScript V8 engine compile and install
   echo "Preparing to compile and install the JavaScript V8 engine."
   echo

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -171,17 +171,8 @@ echo "$chroot_cmd update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 
 chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75
 # gcc 9 done
 
-[ -z "$TRAVIS" ] && bash script/confirm.bash 'Install V8 JavaScript Engine (submissions in JavaScript will fail without this!)' && {
-  echo "Preparing to compile and install the V8 JavaScript Engine."
-  echo
-  echo "If this fails, visit https://v8.dev/docs/build and follow the instructions."
-  echo "This may take a while..."
-  echo
-
+[ -z "$TRAVIS" ] && bash script/confirm.bash 'Install the V8 JavaScript Engine (submissions in JavaScript will fail without this!)' && {
   bash script/install/v8.bash
-
-  echo "JavaScript V8 installed into $ISOLATE_ROOT/usr/local/bin/d8"
-  echo
 }
 
 echo 'Finished chroot installs!'

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -170,7 +170,7 @@ chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g
 # gcc 9 done
 
 [ -z "$TRAVIS" ] && bash script/confirm.bash 'Install the V8 JavaScript Engine (submissions in JavaScript will fail without this!)' && {
-  chroot "$ISOLATE_ROOT" bash < script/install/v8.bash
+  HOME=/root chroot "$ISOLATE_ROOT" bash < script/install/v8.bash
 }
 
 umount "$ISOLATE_ROOT/proc"

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -177,39 +177,9 @@ chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g
   echo "If this fails, visit https://v8.dev/docs/build and follow the instructions."
   echo "This may take a while..."
   echo
-  set -x
 
-  : Making temporary directory
-  mkdir ~/v8-build
-  cd ~/v8-build
+  bash script/install/v8.bash
 
-  : Installing depot_tools
-  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-  export PATH="$PATH:$PWD/depot_tools"
-  gclient
-
-  : Getting V8 source code
-  mkdir v8
-  cd v8
-  fetch v8
-  cd v8
-
-  : Installing additional build dependencies
-  gclient sync
-  ./build/install-build-deps.sh
-
-  : Compiling V8
-  ./tools/dev/v8gen.py x64.release -- v8_use_external_startup_data=false
-  ninja -C out.gn/x64.release d8
-
-  : Copying executable into place
-  cp ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8
-
-  : Cleaning up
-  cd ~
-  rm -r v8-build
-
-  set +x
   echo "JavaScript V8 installed into $ISOLATE_ROOT/usr/bin/d8"
   echo
 }

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -171,79 +171,48 @@ echo "$chroot_cmd update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 
 chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75
 # gcc 9 done
 
-# JavaScript V8 engine compile and install
-echo "Preparing to compile and install the JavaScript V8 engine."
-echo ""
-echo "If this fails, visit https://v8.dev/docs/build and follow the instructions."
-echo "This may take a while ..."
-echo ""
+[ -z "$TRAVIS" ] && { # if not in Travis-CI
+  # JavaScript V8 engine compile and install
+  echo "Preparing to compile and install the JavaScript V8 engine."
+  echo
+  echo "If this fails, visit https://v8.dev/docs/build and follow the instructions."
+  echo "This may take a while ..."
+  echo
+  set -x
 
-echo "Making temporary directory"
-echo "$chroot_cmd cd /"
-chroot "$ISOLATE_ROOT" cd /
-echo "$chroot_cmd mkdir v8-tools"
-chroot "$ISOLATE_ROOT" mkdir v8-tools
-echo "$chroot_cmd cd v8-tools"
-chroot "$ISOLATE_ROOT" cd v8-tools
-echo ""
+  : Making temporary directory
+  mkdir ~/v8-build
+  cd ~/v8-build
 
-echo "Getting V8 source"
-echo "$chroot_cmd git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git"
-chroot "$ISOLATE_ROOT" git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-echo "$chroot_cmd export PATH=`pwd`/depot_tools:\"$PATH\""
-chroot "$ISOLATE_ROOT" export PATH=`pwd`/depot_tools:"$PATH"
-echo "$chroot_cmd cd .."
-chroot "$ISOLATE_ROOT" cd ..
-echo "$chroot_cmd mkdir v8"
-chroot "$ISOLATE_ROOT" mkdir v8
-echo "$chroot_cmd cd v8"
-chroot "$ISOLATE_ROOT" cd v8
-echo "$chroot_cmd fetch v8"
-chroot "$ISOLATE_ROOT" fetch v8
-echo ""
+  : Installing depot_tools
+  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  export PATH="$PATH:$PWD/depot_tools"
+  gclient
 
-echo "Syncing and checking out"
-echo "$chroot_cmd cd v8"
-chroot "$ISOLATE_ROOT" cd v8
-echo "$chroot_cmd gclient sync"
-chroot "$ISOLATE_ROOT" gclient sync
-echo ""
+  : Getting V8 source code
+  mkdir v8
+  cd v8
+  fetch v8
+  cd v8
 
-echo "Installing dependencies needed to build V8"
-echo "$chroot_cmd ./build/install-build-deps.sh"
-chroot "$ISOLATE_ROOT" ./build/install-build-deps.sh
+  : Installing additional build dependencies
+  gclient sync
+  ./build/install-build-deps.sh
 
-echo "Syncing again"
-echo "$chroot_cmd git pull origin master"
-chroot "$ISOLATE_ROOT" git pull origin master
-echo "$chroot_cmd gclient sync"
-chroot "$ISOLATE_ROOT" gclient sync
-echo ""
+  : Compiling V8
+  ./tools/dev/v8gen.py x64.release -- v8_use_external_startup_data=false
+  ninja -C out.gn/x64.release d8
 
-echo "Compile time!"
-echo "$chroot_cmd ./tools/dev/gm.py x64.release"
-chroot "$ISOLATE_ROOT" ./tools/dev/gm.py x64.release
-echo ""
+  : Copying executable into place
+  cp ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8
 
-echo "Moving executable into place"
-echo "$chroot_cmd mv ./out/x64.release/d8 /usr/bin/d8"
-chroot "$ISOLATE_ROOT" mv ./out/x64.release/d8 /usr/bin/d8
-echo "$chroot_cmd mv ./out/x64.release/snapshot_blob.bin /usr/bin/snapshot_blob.bin"
-chroot "$ISOLATE_ROOT" mv ./out/x64.release/snapshot_blob.bin /usr/bin/snapshot_blob.bin
-echo ""
+  : Cleaning up
+  cd ~
+  rm -r v8-build
 
-echo "Removing source files"
-echo "$chroot_cmd cd /"
-chroot "$ISOLATE_ROOT" cd /
-echo "$chroot_cmd rm -r v8"
-chroot "$ISOLATE_ROOT" rm -r v8
-echo "$chroot_cmd rm -r v8-tools"
-chroot "$ISOLATE_ROOT" rm -r v8-tools
+  set +x
+  echo "JavaScript V8 installed into $ISOLATE_ROOT/usr/bin/d8"
+  echo
+}
 
-echo "Yay! JavaScript hopefully installed."
-echo "Do /usr/bin/d8 from chroot to test it out."
-echo ""
-# JavaScript done
-
-# let user know that chroot installs are finished
-echo "Finished chroot installs!"
+echo 'Finished chroot installs!'

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -170,7 +170,7 @@ chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g
 # gcc 9 done
 
 [ -z "$TRAVIS" ] && bash script/confirm.bash 'Install the V8 JavaScript Engine (submissions in JavaScript will fail without this!)' && {
-  bash script/install/v8.bash
+  chroot "$ISOLATE_ROOT" bash < script/install/v8.bash
 }
 
 umount "$ISOLATE_ROOT/proc"

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -171,12 +171,11 @@ echo "$chroot_cmd update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 
 chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75
 # gcc 9 done
 
-[ -z "$TRAVIS" ] && bash script/confirm.bash 'Install JavaScript V8 (submissions in V8 will fail without this!)' && {
-  # JavaScript V8 engine compile and install
-  echo "Preparing to compile and install the JavaScript V8 engine."
+[ -z "$TRAVIS" ] && bash script/confirm.bash 'Install V8 JavaScript Engine (submissions in JavaScript will fail without this!)' && {
+  echo "Preparing to compile and install the V8 JavaScript Engine."
   echo
   echo "If this fails, visit https://v8.dev/docs/build and follow the instructions."
-  echo "This may take a while ..."
+  echo "This may take a while..."
   echo
   set -x
 

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -171,5 +171,79 @@ echo "$chroot_cmd update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 
 chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 75
 # gcc 9 done
 
-# let user know that chroot installs are finished
+# JavaScript V8 engine compile and install
+echo "Preparing to compile and install the JavaScript V8 engine."
+echo ""
+echo "If this fails, visit https://v8.dev/docs/build and follow the instructions."
+echo "This may take a while ..."
+echo ""
 
+echo "Making temporary directory"
+echo "$chroot_cmd cd /"
+chroot "$ISOLATE_ROOT" cd /
+echo "$chroot_cmd mkdir v8-tools"
+chroot "$ISOLATE_ROOT" mkdir v8-tools
+echo "$chroot_cmd cd v8-tools"
+chroot "$ISOLATE_ROOT" cd v8-tools
+echo ""
+
+echo "Getting V8 source"
+echo "$chroot_cmd git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+chroot "$ISOLATE_ROOT" git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+echo "$chroot_cmd export PATH=`pwd`/depot_tools:\"$PATH\""
+chroot "$ISOLATE_ROOT" export PATH=`pwd`/depot_tools:"$PATH"
+echo "$chroot_cmd cd .."
+chroot "$ISOLATE_ROOT" cd ..
+echo "$chroot_cmd mkdir v8"
+chroot "$ISOLATE_ROOT" mkdir v8
+echo "$chroot_cmd cd v8"
+chroot "$ISOLATE_ROOT" cd v8
+echo "$chroot_cmd fetch v8"
+chroot "$ISOLATE_ROOT" fetch v8
+echo ""
+
+echo "Syncing and checking out"
+echo "$chroot_cmd cd v8"
+chroot "$ISOLATE_ROOT" cd v8
+echo "$chroot_cmd gclient sync"
+chroot "$ISOLATE_ROOT" gclient sync
+echo ""
+
+echo "Installing dependencies needed to build V8"
+echo "$chroot_cmd ./build/install-build-deps.sh"
+chroot "$ISOLATE_ROOT" ./build/install-build-deps.sh
+
+echo "Syncing again"
+echo "$chroot_cmd git pull origin master"
+chroot "$ISOLATE_ROOT" git pull origin master
+echo "$chroot_cmd gclient sync"
+chroot "$ISOLATE_ROOT" gclient sync
+echo ""
+
+echo "Compile time!"
+echo "$chroot_cmd ./tools/dev/gm.py x64.release"
+chroot "$ISOLATE_ROOT" ./tools/dev/gm.py x64.release
+echo ""
+
+echo "Moving executable into place"
+echo "$chroot_cmd mv ./out/x64.release/d8 /usr/bin/d8"
+chroot "$ISOLATE_ROOT" mv ./out/x64.release/d8 /usr/bin/d8
+echo "$chroot_cmd mv ./out/x64.release/snapshot_blob.bin /usr/bin/snapshot_blob.bin"
+chroot "$ISOLATE_ROOT" mv ./out/x64.release/snapshot_blob.bin /usr/bin/snapshot_blob.bin
+echo ""
+
+echo "Removing source files"
+echo "$chroot_cmd cd /"
+chroot "$ISOLATE_ROOT" cd /
+echo "$chroot_cmd rm -r v8"
+chroot "$ISOLATE_ROOT" rm -r v8
+echo "$chroot_cmd rm -r v8-tools"
+chroot "$ISOLATE_ROOT" rm -r v8-tools
+
+echo "Yay! JavaScript hopefully installed."
+echo "Do /usr/bin/d8 from chroot to test it out."
+echo ""
+# JavaScript done
+
+# let user know that chroot installs are finished
+echo "Finished chroot installs!"

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -180,7 +180,7 @@ chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g
 
   bash script/install/v8.bash
 
-  echo "JavaScript V8 installed into $ISOLATE_ROOT/usr/bin/d8"
+  echo "JavaScript V8 installed into $ISOLATE_ROOT/usr/local/bin/d8"
   echo
 }
 

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -139,8 +139,6 @@ EOF
 
 }
 
-umount "$ISOLATE_ROOT/proc"
-
 if [ ! -f "$ISOLATE_ROOT/usr/bin/cint.rb" ] ; then
   cmd="cp `dirname $0`/cint.rb $ISOLATE_ROOT/usr/bin"
   echo "$cmd"
@@ -174,5 +172,7 @@ chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g
 [ -z "$TRAVIS" ] && bash script/confirm.bash 'Install the V8 JavaScript Engine (submissions in JavaScript will fail without this!)' && {
   bash script/install/v8.bash
 }
+
+umount "$ISOLATE_ROOT/proc"
 
 echo 'Finished chroot installs!'

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -170,7 +170,7 @@ chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/g++ g++ /usr/bin/g
 # gcc 9 done
 
 [ -z "$TRAVIS" ] && bash script/confirm.bash 'Install the V8 JavaScript Engine (submissions in JavaScript will fail without this!)' && {
-  HOME=/root chroot "$ISOLATE_ROOT" bash < script/install/v8.bash
+  HOME=/root ISOLATE_ROOT= chroot "$ISOLATE_ROOT" bash < script/install/v8.bash
 }
 
 umount "$ISOLATE_ROOT/proc"

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -8,9 +8,9 @@ echo
 set -x
 
 : Installing dependencies
-apt-get install python -y
-apt-get install git -y
-apt-get install wget -y
+sudo apt-get install python -y
+sudo apt-get install git -y
+sudo apt-get install wget -y
 
 : Making temporary directory
 mkdir ~/v8-build

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -7,6 +7,11 @@ echo "This may take a while..."
 echo
 set -x
 
+: Installing dependencies
+apt-get install python -y
+apt-get install git -y
+apt-get install wget -y
+
 : Making temporary directory
 mkdir ~/v8-build
 cd ~/v8-build

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -27,7 +27,7 @@ gclient sync
 ninja -C out.gn/x64.release d8
 
 : Moving executable into place
-sudo mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8 && {
+sudo mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/local/bin/d8 && {
 
   : Cleaning up # only if mv succeeded, so user can inspect build errors
   cd ~

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# builds V8 (JavaScript engine) from source
+
+set -x
+
+: Making temporary directory
+mkdir ~/v8-build
+cd ~/v8-build
+
+: Installing depot_tools
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH="$PATH:$PWD/depot_tools"
+gclient
+
+: Getting V8 source code
+mkdir v8
+cd v8
+fetch v8
+cd v8
+
+: Installing additional build dependencies
+gclient sync
+./build/install-build-deps.sh
+
+: Compiling V8
+./tools/dev/v8gen.py x64.release -- v8_use_external_startup_data=false
+ninja -C out.gn/x64.release d8
+
+: Copying executable into place
+cp ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8
+
+: Cleaning up
+cd ~
+rm -r v8-build
+
+set +x

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -14,7 +14,7 @@ sudo apt-get install wget -y
 
 : Making temporary directory
 mkdir ~/v8-build
-cd ~/v8-build
+cd ~/v8-build || exit
 
 : Installing depot_tools
 git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -19,7 +19,7 @@ cd ~/v8-build
 : Installing depot_tools
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 export PATH="$PATH:$PWD/depot_tools"
-gclient
+gclient --version
 
 : Getting V8 source code
 mkdir v8

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# builds V8 (JavaScript engine) from source
 
+echo "Preparing to compile and install the V8 JavaScript Engine."
+echo
+echo "If this fails, visit https://v8.dev/docs/build and follow the instructions."
+echo "This may take a while..."
+echo
 set -x
 
 : Making temporary directory
@@ -35,3 +39,5 @@ sudo mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/local/bin/d8 && {
 }
 
 set +x
+echo "JavaScript V8 installed into $ISOLATE_ROOT/usr/local/bin/d8"
+echo

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -17,18 +17,18 @@ mkdir ~/v8-build
 cd ~/v8-build
 
 : Installing depot_tools
-git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
 export PATH="$PATH:$PWD/depot_tools"
 gclient --version
 
 : Getting V8 source code
 mkdir v8
 cd v8
-fetch v8
+fetch --no-history v8
 cd v8
 
 : Installing additional build dependencies
-gclient sync
+gclient sync --no-history
 ./build/install-build-deps.sh
 
 : Compiling V8

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -16,6 +16,9 @@ sudo apt-get install wget -y
 build="$HOME/v8-build"
 mkdir "$build"
 cd "$build" || exit
+# The build process creates things in $HOME (.vpython_cipd_cache and .vpython-root).
+# Set $HOME to the build directory so they will be cleaned up.
+HOME="$build"
 
 : Installing depot_tools
 git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -27,10 +27,11 @@ gclient sync
 ninja -C out.gn/x64.release d8
 
 : Moving executable into place
-mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8
+mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8 && {
 
-: Cleaning up
-cd ~
-rm -r v8-build
+  : Cleaning up # only if mv succeeded, so user can inspect build errors
+  cd ~
+  rm -r v8-build
+}
 
 set +x

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -29,7 +29,7 @@ cd v8
 
 : Installing additional build dependencies
 gclient sync --no-history
-./build/install-build-deps.sh
+./build/install-build-deps.sh --no-syms --no-arm --no-chromeos-fonts --no-nacl
 
 : Compiling V8
 ./tools/dev/v8gen.py x64.release -- v8_use_external_startup_data=false

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -26,8 +26,8 @@ gclient sync
 ./tools/dev/v8gen.py x64.release -- v8_use_external_startup_data=false
 ninja -C out.gn/x64.release d8
 
-: Copying executable into place
-cp ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8
+: Moving executable into place
+mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8
 
 : Cleaning up
 cd ~

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -31,7 +31,7 @@ mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8 && {
 
   : Cleaning up # only if mv succeeded, so user can inspect build errors
   cd ~
-  rm -r v8-build
+  rm -rf v8-build
 }
 
 set +x

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -13,8 +13,9 @@ sudo apt-get install git -y
 sudo apt-get install wget -y
 
 : Making temporary directory
-mkdir ~/v8-build
-cd ~/v8-build || exit
+build="$HOME/v8-build"
+mkdir "$build"
+cd "$build" || exit
 
 : Installing depot_tools
 git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
@@ -39,8 +40,7 @@ ninja -C out.gn/x64.release d8
 sudo mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/local/bin/d8 && {
 
   : Cleaning up # only if mv succeeded, so user can inspect build errors
-  cd ~
-  rm -rf ~/v8-build
+  rm -rf "$build"
 }
 
 set +x

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -31,7 +31,7 @@ mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8 && {
 
   : Cleaning up # only if mv succeeded, so user can inspect build errors
   cd ~
-  rm -rf v8-build
+  rm -rf ~/v8-build
 }
 
 set +x

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -27,7 +27,7 @@ gclient sync
 ninja -C out.gn/x64.release d8
 
 : Moving executable into place
-mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8 && {
+sudo mv ./out.gn/x64.release/d8 "$ISOLATE_ROOT"/usr/bin/d8 && {
 
   : Cleaning up # only if mv succeeded, so user can inspect build errors
   cd ~


### PR DESCRIPTION
Compared Nodejs and V8 engine. Nodejs displayed much slower I/O than Python and the syntax for receiving input is horrible. V8 provides `readline` and much more competitive performance. Hence, we propose to support JavaScript by compiling the V8 engine from source and installing it in the sandbox. Has been tested on a local install of nztrain.

JavaScript is a popular language likely to remain relevant for the foreseeable future. It is commonly taught in schools to a basic level. I have received a few requests for us to support it.

**Note: The updated install script has not been tested.**

This has already been done on codeforces. https://codeforces.com/blog/entry/10024
https://v8.dev/docs/build
https://remusao.github.io/posts/compiling-v8-ubuntu-16-04.html