### PR TITLE
Add commented-out commands to install Python 2 in the chroot

### DIFF
--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -100,6 +100,8 @@ chroot "$ISOLATE_ROOT" apt-get install openjdk-11-jdk # Java
 
 [ -z "$TRAVIS" ] && { # if not in Travis-CI
 
+  # echo "$chroot_install python"
+  # chroot "$ISOLATE_ROOT" apt-get install python # Python 2 (deprecated)
   echo "$chroot_install python3.4"
   chroot "$ISOLATE_ROOT" apt-get install python3.4 # Python 3.4
   echo "$chroot_install python3.8"


### PR DESCRIPTION
Python 2 used to be installed automatically as a dependency of python-software-properties, but that was removed in commit 1ebd684 ("Remove debootstrap package for Ubuntu 12.04", 2020-01-21).

Python 2 has reached end-of-life and is no longer displayed as an option for submissions, so it shouldn't be installed by default. However, some deployments might need to support old Python 2
submissions, so I've added the commands as comments.