### PR TITLE
Enable "universe" component of security repository in sources.list

### DIFF
--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -34,7 +34,7 @@ if [[ "$ISOLATE_ROOT" != "/" ]] && [[ ! -d "$ISOLATE_ROOT" ]]; then
   # add sources
   echo deb http://archive.ubuntu.com/ubuntu/ $SUITE-updates main restricted >> /srv/chroot/nztrain/etc/apt/sources.list
   echo deb http://archive.ubuntu.com/ubuntu/ $SUITE universe >> /srv/chroot/nztrain/etc/apt/sources.list
-  echo deb http://security.ubuntu.com/ubuntu $SUITE-security main restricted >> /srv/chroot/nztrain/etc/apt/sources.list
+  echo deb http://security.ubuntu.com/ubuntu $SUITE-security main restricted universe >> /srv/chroot/nztrain/etc/apt/sources.list
   echo deb http://nz.archive.ubuntu.com/ubuntu/ $SUITE multiverse >> /srv/chroot/nztrain/etc/apt/sources.list
   echo deb-src http://nz.archive.ubuntu.com/ubuntu/ $SUITE multiverse >> /srv/chroot/nztrain/etc/apt/sources.list
   echo deb http://nz.archive.ubuntu.com/ubuntu/ $SUITE-updates multiverse >> /srv/chroot/nztrain/etc/apt/sources.list


### PR DESCRIPTION
(in debootstrap script)

The "universe" component is enabled for the "$SUITE" repository, so it should also be enabled for "$SUITE-security" to get security updates.

Discovered because it caused dependency errors when building V8 (https://github.com/NZOI/nztrain/pull/49#discussion_r369930432).

The sources.list file could do with some more cleanup. Leaving it for now to reduce merge conflicts with commit 9f5ff36 ("Fix isolate root path in debootstrap script", 2019-01-30).

This will need to be applied manually on the server.