### PR TITLE
Set each user's default option to their last submitted lanugage

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -59,7 +59,7 @@ class Language < ActiveRecord::Base
   # for the selection dropdown
   def self.grouped_submission_options
     current = ["c++", "c", "python", "java", "haskell", "ruby", "j"]  # language group identifiers, order is preserved
-    other = ["c++14", "c++11", "c99"]  # language identifiers, ordered by language name
+    other = ["c++14", "c99"]  # language identifiers, ordered by language name
     current_langs = LanguageGroup.where(:identifier => current).preload(:current_language).map(&:current_language)
     current_options = current_langs.sort_by { |lang| current.index(lang.group.identifier) }.map { |lang| [lang.name, lang.id] }
     other_options = Language.where(:identifier => other).order(:name).pluck(:name, :id)

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -67,10 +67,6 @@ class Language < ActiveRecord::Base
       "Other" => Hash[other_options] }
   end
 
-  def self.default
-    LanguageGroup.find_by(identifier: 'c++').current_language
-  end
-
   def self.infer(ext)
     case ext
     when *%w[.cpp]

--- a/app/views/problems/submit.html.erb
+++ b/app/views/problems/submit.html.erb
@@ -12,7 +12,7 @@
 <%= form_for @submission, :html => {:multipart => true}, :url => submit_problem_path(@problem) do |f| %>
   <div class="subfield">
     Language: 
-    <%= f.select :language_id, grouped_options_for_select(Language.grouped_submission_options, @submission.language_id || Language.default.id) %>
+    <%= f.select :language_id, grouped_options_for_select(Language.grouped_submission_options, @submission.language_id || @current_user.submissions.last&.language_id) %>
   </div>
   <div class="field">
     Source file: 
@@ -30,7 +30,7 @@
   <%= form_for @submission, :url => submit_problem_path(@problem) do |f| %>
     <div class="subfield">
       Language: 
-      <%= f.select :language_id, grouped_options_for_select(Language.grouped_submission_options, @submission.language_id || Language.default.id) %>
+      <%= f.select :language_id, grouped_options_for_select(Language.grouped_submission_options, @submission.language_id || @current_user.submissions.last&.language_id) %>
     </div>
     <div class="subactions">
       <%= f.submit 'Submit' %>


### PR DESCRIPTION
See https://github.com/NZOI/nztrain/pull/64#discussion_r372315509.

If the last submitted language is no longer selectable, or the user has not yet made any submissions, it will default to the first option in the dropdown. Also, since the ordering of the current languages
is manually defined, I've removed `Language.default`.