### PR TITLE
Fix null attributes of timestamps to match server

### DIFF
--- a/db/migrate/20110819224757_devise_create_users.rb
+++ b/db/migrate/20110819224757_devise_create_users.rb
@@ -37,7 +37,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
       # t.string :authentication_token
 
       t.boolean :is_admin, :default => false
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :users, :email,                :unique => true

--- a/db/migrate/20110820005833_create_test_cases.rb
+++ b/db/migrate/20110820005833_create_test_cases.rb
@@ -7,7 +7,7 @@ class CreateTestCases < ActiveRecord::Migration
       t.string :description
       t.integer :problem_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20110820010205_create_problems.rb
+++ b/db/migrate/20110820010205_create_problems.rb
@@ -9,7 +9,7 @@ class CreateProblems < ActiveRecord::Migration
       t.decimal :time_limit
       t.integer :user_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20110820013719_create_submissions.rb
+++ b/db/migrate/20110820013719_create_submissions.rb
@@ -7,7 +7,7 @@ class CreateSubmissions < ActiveRecord::Migration
       t.integer :user_id
       t.integer :problem_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20110904033519_create_contest_relations.rb
+++ b/db/migrate/20110904033519_create_contest_relations.rb
@@ -5,7 +5,7 @@ class CreateContestRelations < ActiveRecord::Migration
       t.integer :contest_id
       t.datetime :started_at
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20110904033742_create_contests.rb
+++ b/db/migrate/20110904033742_create_contests.rb
@@ -7,7 +7,7 @@ class CreateContests < ActiveRecord::Migration
       t.decimal :duration
       t.integer :user_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20110924030742_create_groups.rb
+++ b/db/migrate/20110924030742_create_groups.rb
@@ -3,7 +3,7 @@ class CreateGroups < ActiveRecord::Migration
     create_table :groups do |t|
       t.string :name
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20120119025544_create_problem_sets.rb
+++ b/db/migrate/20120119025544_create_problem_sets.rb
@@ -3,7 +3,7 @@ class CreateProblemSets < ActiveRecord::Migration
     create_table :problem_sets do |t|
       t.string :title
       t.integer :user_id
-      t.timestamps
+      t.timestamps null: true
     end
     # add association tables
     create_table :problem_sets_problems, :id => false do |t|

--- a/db/migrate/20120128235138_create_evaluators.rb
+++ b/db/migrate/20120128235138_create_evaluators.rb
@@ -6,7 +6,7 @@ class CreateEvaluators < ActiveRecord::Migration
       t.text :source, :null => false, :default => ""
       t.integer :user_id, :null => false
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     execute "INSERT INTO evaluators (name, source, user_id) SELECT title AS name, evaluator AS source, user_id FROM problems WHERE evaluator IS NOT NULL;"

--- a/db/migrate/20120201113029_add_sessions_table.rb
+++ b/db/migrate/20120201113029_add_sessions_table.rb
@@ -3,7 +3,7 @@ class AddSessionsTable < ActiveRecord::Migration
     create_table :sessions do |t|
       t.string :session_id, :null => false
       t.text :data
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :sessions, :session_id

--- a/db/migrate/20120210235859_create_test_sets.rb
+++ b/db/migrate/20120210235859_create_test_sets.rb
@@ -5,7 +5,7 @@ class CreateTestSets < ActiveRecord::Migration
       t.integer :points
       t.string :name
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_column :test_cases, :test_set_id, :integer
     TestCase.all.each do |tc|

--- a/db/migrate/20130107015143_create_ai_contests.rb
+++ b/db/migrate/20130107015143_create_ai_contests.rb
@@ -10,7 +10,7 @@ class CreateAiContests < ActiveRecord::Migration
       t.text :statement
       t.string :judge
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20130107025725_create_ai_submissions.rb
+++ b/db/migrate/20130107025725_create_ai_submissions.rb
@@ -6,7 +6,7 @@ class CreateAiSubmissions < ActiveRecord::Migration
       t.integer :user_id
       t.integer :ai_contest_id
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20130108005444_create_ai_contest_games.rb
+++ b/db/migrate/20130108005444_create_ai_contest_games.rb
@@ -8,7 +8,7 @@ class CreateAiContestGames < ActiveRecord::Migration
       t.integer :score_1
       t.integer :score_2
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20130926105411_create_requests.rb
+++ b/db/migrate/20130926105411_create_requests.rb
@@ -8,8 +8,8 @@ class CreateRequests < ActiveRecord::Migration
       t.integer :status, :null => false, :default => 0
       t.references :requestee
       t.datetime :expired_at, :null => false, :default => :infinity
- 
-      t.timestamps
+
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20131001083843_create_file_attachments.rb
+++ b/db/migrate/20131001083843_create_file_attachments.rb
@@ -5,7 +5,7 @@ class CreateFileAttachments < ActiveRecord::Migration
       t.string :file_attachment, :string
       t.references :owner
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     create_table :group_file_attachments do |t|

--- a/db/migrate/20131007002316_create_test_case_relations.rb
+++ b/db/migrate/20131007002316_create_test_case_relations.rb
@@ -3,7 +3,7 @@ class CreateTestCaseRelations < ActiveRecord::Migration
     create_table :test_case_relations do |t|
       t.integer :test_case_id
       t.integer :test_set_id
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20131013045616_create_languages.rb
+++ b/db/migrate/20131013045616_create_languages.rb
@@ -5,7 +5,7 @@ class CreateLanguages < ActiveRecord::Migration
       t.string :compiler
       t.boolean :is_interpreted
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20131208014408_add_language_group_model.rb
+++ b/db/migrate/20131208014408_add_language_group_model.rb
@@ -4,7 +4,7 @@ class AddLanguageGroupModel < ActiveRecord::Migration
       t.string :identifier
       t.string :name
       t.references :current_language
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :language_groups, :identifier, :unique => true

--- a/db/migrate/20131221014009_create_user_problem_relation.rb
+++ b/db/migrate/20131221014009_create_user_problem_relation.rb
@@ -33,7 +33,7 @@ class CreateUserProblemRelation < ActiveRecord::Migration
 
       t.timestamp :last_viewed_at
       t.timestamp :first_viewed_at
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :user_problem_relations, [:user_id, :problem_id], unique: true

--- a/db/migrate/20150330223537_create_forem_topics.forem.rb
+++ b/db/migrate/20150330223537_create_forem_topics.forem.rb
@@ -6,7 +6,7 @@ class CreateForemTopics < ActiveRecord::Migration
       t.integer :user_id
       t.string :subject
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150330223538_create_forem_posts.forem.rb
+++ b/db/migrate/20150330223538_create_forem_posts.forem.rb
@@ -6,7 +6,7 @@ class CreateForemPosts < ActiveRecord::Migration
       t.text :text
       t.integer :user_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150330223546_create_forem_categories.forem.rb
+++ b/db/migrate/20150330223546_create_forem_categories.forem.rb
@@ -3,7 +3,7 @@ class CreateForemCategories < ActiveRecord::Migration
   def change
     create_table :forem_categories do |t|
       t.string :name, :null => false
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20160123214252_create_contest_supervisors.rb
+++ b/db/migrate/20160123214252_create_contest_supervisors.rb
@@ -6,7 +6,7 @@ class CreateContestSupervisors < ActiveRecord::Migration
       t.string :site_type
       t.integer :site_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
     t.text     "record"
     t.integer  "score_1"
     t.integer  "score_2"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.integer  "iteration"
     t.text     "judge_output"
   end
@@ -40,8 +40,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
     t.text     "sample_ai"
     t.text     "statement"
     t.text     "judge"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.integer  "iterations"
     t.integer  "iterations_preview"
   end
@@ -51,8 +51,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
     t.string   "language"
     t.integer  "user_id"
     t.integer  "ai_contest_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.string   "name"
     t.boolean  "active",        default: false
   end
@@ -138,8 +138,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
     t.string   "name"
     t.string   "file_attachment"
     t.integer  "owner_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   create_table "filelinks", force: true do |t|
@@ -310,8 +310,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
     t.string   "identifier"
     t.string   "name"
     t.integer  "current_language_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
   end
 
   add_index "language_groups", ["identifier"], name: "index_language_groups_on_identifier", unique: true, using: :btree
@@ -320,8 +320,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
     t.string   "identifier"
     t.string   "compiler"
     t.boolean  "interpreted"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "extension"
     t.boolean  "compiled"
     t.string   "name"
@@ -399,8 +399,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
     t.integer  "status",       default: 0,        null: false
     t.integer  "requestee_id"
     t.datetime "expired_at",   default: Infinity, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   create_table "roles", force: true do |t|
@@ -464,8 +464,8 @@ ActiveRecord::Schema.define(version: 20160131000430) do
   create_table "test_case_relations", force: true do |t|
     t.integer  "test_case_id"
     t.integer  "test_set_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   add_index "test_case_relations", ["test_case_id"], name: "index_test_case_relations_on_test_case_id", using: :btree


### PR DESCRIPTION
See commit messages for details.

This pull request changes the timestamp columns in the version-controlled schema and the migrations to match the current schema on the server. If we want to make all the timestamp columns consistently use `null: true` or `null: false` it should be done separately.

Note that there is another inconsistency which is not addressed here: the `limit: 128` attribute on the users.encrypted_passwords column (also introduced in [fe025a8](https://github.com/NZOI/nztrain/commit/fe025a81727e2e467b6f9f7ed7be4f8222c50709#diff-1acd2e7e27a227829d5d14a91c863bb6L517)).