### PR TITLE
Fix scroll redraw on Safari for main container

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -66,9 +66,9 @@ var duration = 250;
 function shrink() {
   createCookie("expanded", "false", 31);
   $("#side").animate({width:'50px'}, duration);
-  $('#main-menu').animate({'left':'50px'}, duration);
+  $('#main-menu').animate({'margin-left':'50px'}, duration);
   $('#side-minify').html("&#9654;");
-  $('#main').animate({'left':'50px'}, duration);
+  $('#main').animate({'margin-left':'50px'}, duration);
   $('#side-expanded').animate({'opacity':'0'},duration);
   $('#side-contracted').animate({'opacity':'1'}, duration);
 }
@@ -76,9 +76,9 @@ function shrink() {
 function expand() {
   createCookie("expanded", "true", 31);
   $("#side").animate({width:'200px'}, duration);
-  $('#main-menu').animate({'left':'200px'}, duration);
+  $('#main-menu').animate({'margin-left':'200px'}, duration);
   $('#side-minify').html("&#9664;");
-  $('#main').animate({'left':'200px'}, duration);
+  $('#main').animate({'margin-left':'200px'}, duration);
   $('#side-expanded').animate({'opacity':'1'},duration);
   $('#side-contracted').animate({'opacity':'0'}, duration);
 }

--- a/app/assets/stylesheets/nav-superfish.css.erb
+++ b/app/assets/stylesheets/nav-superfish.css.erb
@@ -1,6 +1,5 @@
 #main-menu {
-  position: fixed;
-  left: 200px;
+  margin-left: 200px;
   right: 0px;
   background: #2D2D2D;
   z-index: 10;

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -113,7 +113,6 @@ a.progress_link:hover {
   right: 0;
   bottom: 0;
   overflow-y: auto;
-  outline: none;
 }
 
 #main-container

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -113,6 +113,7 @@ a.progress_link:hover {
   right: 0;
   bottom: 0;
   overflow-y: auto;
+  outline: none;
 }
 
 #main-container

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -109,10 +109,9 @@ a.progress_link:hover {
 
 #main {
   top: 30px;
-  left: 200px;
+  margin-left: 200px;
   right: 0;
   bottom: 0;
-  position: fixed;
   overflow-y: auto;
 }
 

--- a/app/views/layouts/scaffold.html.erb
+++ b/app/views/layouts/scaffold.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main do %>
-  <div id="main" tabindex="-1">
+  <div id="main">
     <% if alert %>
       <div class="messagebox alert"><%= alert %></div>
     <% end %>


### PR DESCRIPTION
Scrolling through pages on Safari is erratic due to spurious paints. The proposed workaround is to replace `position: fixed` with an implicit `position: static` and change the animation functions to update the `margin-left` property instead.