### PR TITLE
Add PyPy

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -59,7 +59,7 @@ class Language < ActiveRecord::Base
   # for the selection dropdown
   def self.grouped_submission_options
     current = ["c++", "c", "python", "csharp", "java", "javascript", "haskell", "ruby", "j"]  # language group identifiers, order is preserved
-    other = ["c++14", "c99", "python3.6pypy"]  # language identifiers, ordered by language name
+    other = ["c++14", "c99", "pypy3"]  # language identifiers, ordered by language name
     current_langs = LanguageGroup.where(:identifier => current).preload(:current_language).map(&:current_language)
     current_options = current_langs.sort_by { |lang| current.index(lang.group.identifier) }.map { |lang| [lang.name, lang.id] }
     other_options = Language.where(:identifier => other).order(:name).pluck(:name, :id)

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -59,7 +59,7 @@ class Language < ActiveRecord::Base
   # for the selection dropdown
   def self.grouped_submission_options
     current = ["c++", "c", "python", "csharp", "java", "javascript", "haskell", "ruby", "j"]  # language group identifiers, order is preserved
-    other = ["c++14", "c99"]  # language identifiers, ordered by language name
+    other = ["c++14", "c99", "python3.6pypy"]  # language identifiers, ordered by language name
     current_langs = LanguageGroup.where(:identifier => current).preload(:current_language).map(&:current_language)
     current_options = current_langs.sort_by { |lang| current.index(lang.group.identifier) }.map { |lang| [lang.name, lang.id] }
     other_options = Language.where(:identifier => other).order(:name).pluck(:name, :id)

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -108,6 +108,9 @@ python:
     python3.8:
       :name: "Python 3.8"
       :interpreter: /usr/bin/python3.8
+    python3.6pypy:
+      :name: "Python 3.6 (PyPy)"
+      :interpreter: /usr/bin/pypy3
 
 ruby:
   :name: Ruby

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -108,8 +108,8 @@ python:
     python3.8:
       :name: "Python 3.8"
       :interpreter: /usr/bin/python3.8
-    python3.6pypy:
-      :name: "Python 3.6 (PyPy)"
+    pypy3:
+      :name: "Python 3.6 (PyPy 7.3)"
       :interpreter: /usr/bin/pypy3
 
 ruby:

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -67,10 +67,9 @@ chroot "$ISOLATE_ROOT" apt-get install software-properties-common # provides add
     chroot "$ISOLATE_ROOT" add-apt-repository ppa:deadsnakes/ppa -y
   fi
 
-  if ! chroot "$ISOLATE_ROOT" apt-cache show pypy3 &>/dev/null; then
-    echo "$chroot_cmd add-apt-repository ppa:pypy/ppa -y"
-    chroot "$ISOLATE_ROOT" add-apt-repository ppa:pypy/ppa -y
-  fi
+  # pypy ppa
+  echo "$chroot_cmd add-apt-repository ppa:pypy/ppa -y"
+  chroot "$ISOLATE_ROOT" add-apt-repository ppa:pypy/ppa -y
 
   # ruby ppa
   echo "$chroot_cmd add-apt-repository ppa:brightbox/ruby-ng -y"

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -67,6 +67,11 @@ chroot "$ISOLATE_ROOT" apt-get install software-properties-common # provides add
     chroot "$ISOLATE_ROOT" add-apt-repository ppa:deadsnakes/ppa -y
   fi
 
+  if ! chroot "$ISOLATE_ROOT" apt-cache show pypy3 &>/dev/null; then
+    echo "$chroot_cmd add-apt-repository ppa:pypy/ppa -y"
+    chroot "$ISOLATE_ROOT" add-apt-repository ppa:pypy/ppa -y
+  fi
+
   # ruby ppa
   echo "$chroot_cmd add-apt-repository ppa:brightbox/ruby-ng -y"
   chroot "$ISOLATE_ROOT" add-apt-repository ppa:brightbox/ruby-ng -y
@@ -130,6 +135,13 @@ chroot "$ISOLATE_ROOT" apt-get install openjdk-11-jdk # Java
   echo "$chroot_install python3.8"
   chroot "$ISOLATE_ROOT" apt-get install python3.8 # Python 3.8
   # note: when updating these Python versions, also update the check for adding the PPA above
+
+  # PyPy https://www.pypy.org
+  # Python 3.6 is the latest version of Python compatible with pypy
+  # https://launchpad.net/~pypy/+archive/ubuntu/ppa (added earlier)
+  echo "$chroot_install pypy3"
+  chroot "$ISOLATE_ROOT" apt-get install pypy3
+
 
   echo "$chroot_install ruby2.2"
   chroot "$ISOLATE_ROOT" apt-get install ruby2.2

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -136,9 +136,8 @@ chroot "$ISOLATE_ROOT" apt-get install openjdk-11-jdk # Java
   chroot "$ISOLATE_ROOT" apt-get install python3.8 # Python 3.8
   # note: when updating these Python versions, also update the check for adding the PPA above
 
-  # PyPy https://www.pypy.org
-  # Python 3.6 is the latest version of Python compatible with pypy
-  # https://launchpad.net/~pypy/+archive/ubuntu/ppa (added earlier)
+  # PyPy
+  # https://www.pypy.org
   echo "$chroot_install pypy3"
   chroot "$ISOLATE_ROOT" apt-get install pypy3
 


### PR DESCRIPTION
Intended as a temporary measure to see how using PyPy to evaluate Python
scripts compares to the more well known CPython. It was agreed that CPython should not be removed.

[PyPy](https://www.pypy.org) is an alternative python interpreter implementation which claims improved performance over the more common CPython.

Three main differences:
1. Repeated string concatenation in PyPy is O(n^2), but CPython has an O(n) optimisation in some cases.
2. In PyPy, the condition `a is b` holds for big integers where as CPython only works for small integers.
3. PyPy is often a few versions behind. Currently, PyPy supports Python 3.6 but 3.8 is the most recent spec supported by CPython.

However, [the spec](https://www.python.org/dev/peps/pep-0008/#programming-recommendations) recommends against relying on the concatenation optimisation present in CPython. The different behaviour of `is` more likely to reduce error than create it, plus using `is` for numerical comparisons is generally discouraged. Hence, the biggest downfall of PyPy appears to be the lag in supported language version. As an advantage, PyPy may offer more consistent behaviour for larger inputs and make it easier to design inclusive test data.

An alternative solution to this problem is
> Another approach for addressing CPython's slowness is to introduce a per-language time factor, so e.g. Python submissions always get twice the time limit. This is used on USACO for example. It's not perfect; some things in Python are really fast (e.g. the built-in sort function is implemented in C and has comparable performance), while other things might be much slower than x2. - @tom93

![ 2020-04-17 at 9 58 17 PM](https://user-images.githubusercontent.com/12654833/79559444-da8b5d80-80f9-11ea-82f4-746cfab975e1.png)
