### PR TITLE
Update owner column in the contest index pages

### DIFF
--- a/app/views/contests/_index.html.erb
+++ b/app/views/contests/_index.html.erb
@@ -31,7 +31,7 @@
     <td><%= contest.end_time.strftime("%b %d, %H:%M") unless contest.end_time.nil? %></td>
     <td><%= contest.duration %></td>
     <% if policy(Contest).update? %>
-      <td><%= link_to handle(contest.owner), contest.owner %></td>
+      <td><%= link_to contest.owner.username, contest.owner if contest.owner.present? %></td>
     <% end %>
     <td><%= contest.get_score(current_user.id) if user_signed_in? %></td>
     <td>

--- a/app/views/contests/_index.html.erb
+++ b/app/views/contests/_index.html.erb
@@ -5,7 +5,9 @@
       <th>Start time</th>
       <th>End time</th>
       <th>Duration</th>
-      <th>User</th>
+      <% if policy(Contest).update? %>
+        <th>Owner</th>
+      <% end %>
       <th>Score</th>
       <th></th>
       <% if policy(Contest).update? %>
@@ -28,7 +30,9 @@
     <td><%= contest.start_time.strftime("%b %d, %H:%M") unless contest.start_time.nil? %></td>
     <td><%= contest.end_time.strftime("%b %d, %H:%M") unless contest.end_time.nil? %></td>
     <td><%= contest.duration %></td>
-    <td><%= contest.owner_id %></td>
+    <% if policy(Contest).update? %>
+      <td><%= link_to handle(contest.owner), contest.owner %></td>
+    <% end %>
     <td><%= contest.get_score(current_user.id) if user_signed_in? %></td>
     <td>
       <% if contest.is_running? && (policy(contest).start?) %>


### PR DESCRIPTION
 - Only display it to admins
 - Change the heading from "User" to "Owner"
 - Display the username (and link to their profile) instead of ID

Based on commits af301f9 (from #103) and 784e99c (from branch 'scoreboard-update').

I used `handle(contest.owner)` instead of `contest.owner.username` so it doesn't crash if the user has been deleted. A side effect is that it displays the full name of the user in addition to their username.

If the owner has been deleted it displays "DELETED". The link will point to a somewhat arbitrary page (e.g. on /contests it points to /contests/my, and on /contests/current it points to /contests/active; I'm not sure exactly why). This doesn't seem like a major issue, and it is already widespread (all the places that use `link_to handle(XXX), XXX` where `XXX` may be nil), so I'm ignoring it.

*Update: changed back to only displaying username, see https://github.com/NZOI/nztrain/pull/109#issuecomment-618441945*