### PR TITLE
Add unit 'hours' to the contest duration in the interface

### DIFF
--- a/app/views/contests/_index.html.erb
+++ b/app/views/contests/_index.html.erb
@@ -27,7 +27,7 @@
     <td><%= contest.name %></td>
     <td><%= contest.start_time.strftime("%b %d, %H:%M") unless contest.start_time.nil? %></td>
     <td><%= contest.end_time.strftime("%b %d, %H:%M") unless contest.end_time.nil? %></td>
-    <td><%= contest.duration %></td>
+    <td><%= contest.duration %> hours</td>
     <td><%= contest.owner_id %></td>
     <td><%= contest.get_score(current_user.id) if user_signed_in? %></td>
     <td>

--- a/app/views/layouts/contest.html.erb
+++ b/app/views/layouts/contest.html.erb
@@ -71,7 +71,7 @@
   <p>
     <b>Start time:</b>  <%= @contest.start_time %><br>
     <b>End time:</b>    <%= @contest.end_time %><br>
-    <b>Duration:</b>    <%= @contest.duration %><br>
+    <b>Duration:</b>    <%= @contest.duration %> hours<br>
     <b>Owner:</b> <%= @contest.owner_id %><br>
   </p>
   <% if @contest.ended? and @contest.finalized_at.nil? and policy(@contest).update? %>


### PR DESCRIPTION
Taken from PR #103, commit af301f9. See previous review comments about pluralisation on https://github.com/NZOI/nztrain/pull/103#discussion_r411322977.