### PR TITLE
Change visibility of problem statement attachment to 'public' in importer

### DIFF
--- a/app/workers/problem_series/import_worker.rb
+++ b/app/workers/problem_series/import_worker.rb
@@ -251,7 +251,7 @@ class ProblemSeries
         original_attachment = filelink.file_attachment
         filelink.file_attachment = nil
         filelink.file_attachment = FileAttachment.new(file_attachment: File.open(paths[:statement]), owner_id: 0, name: "coci-#{problem.name.parameterize}-statement.pdf")
-        filelink.visibility = Filelink::VISIBILITY[:protected]
+        filelink.visibility = Filelink::VISIBILITY[:public]
         if filelink.save
           log "Statement attached for problem #{data[:name]}."
         else


### PR DESCRIPTION
From #106.

The problem series import worker previously set the visibility of the file attachment containing the imported statement to 'protected'.

That doesn't make sense, because 'protected' means users can view the file if they are *not* currently competing (comment: [app/models/filelink.rb:17](https://github.com/NZOI/nztrain/blob/843d01e5a25965046fc06742beb615878065d11e/app/models/filelink.rb#L17), logic: [app/policies/filelink_policy.rb:26](https://github.com/NZOI/nztrain/blob/843d01e5a25965046fc06742beb615878065d11e/app/policies/filelink_policy.rb#L26)).

As discussed in #106 (specifically https://github.com/NZOI/nztrain/issues/106#issuecomment-617556022 by @Holmes98), the purpose of 'protected' is probably to prevent access to file attachments of other problems/groups during closed-book contests. It does not make sense to use it for problem statements, because users need to be able to view them during the contest.

This commit changes the visibility to 'public'. It is safe (in the sense that it won't make the problem statements visible before the user starts the contest) because the controller also checks that the
containing problem is accessible (see [app/controllers/filelinks/roots_controller.rb:51](https://github.com/NZOI/nztrain/blob/843d01e5a25965046fc06742beb615878065d11e/app/controllers/filelinks/roots_controller.rb#L51:L63)).