### PR TITLE
Run 'apt-get update' before installing any packages to avoid stale package index

### DIFF
--- a/script/install.bash
+++ b/script/install.bash
@@ -26,6 +26,8 @@ if [ ! -f script/update.time ]; then
   echo 2000-01-01+00:00:00 > script/update.time
 fi
 
+sudo apt-get update || exit 1
+
 bash script/install/ruby.bash || exit 1 # check ruby version
 
 bash script/install/postgresql.bash || exit 1 # create user & db if it doesn't exist


### PR DESCRIPTION
Fixes [Travis CI build failure](https://travis-ci.org/github/NZOI/nztrain/builds/679338637) when removing maxmind.bash in #108.