### PR TITLE
Forbid commas in :by_user and :by_problem segments of /submissions route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,7 @@ NZTrain::Application.routes.draw do
 
   resources :submissions, :except => [:new,:create] do
     collection do
-      get '(by_user/:by_user)(/by_problem/:by_problem)', :action => :index, :constraints => {:by_user => /[\d,]+/, :by_problem => /[\d,]+/}
+      get '(by_user/:by_user)(/by_problem/:by_problem)', :action => :index, :constraints => {:by_user => /\d+/, :by_problem => /\d+/}
       get 'my', :to => 'submissions#index', :defaults => { :filter => 'my' }
     end
     member do


### PR DESCRIPTION
In theory it might make sense to filter by multiple users/problems, but currently the code assumes each parameter contains a single ID.