### PR TITLE
Fix type mismatch when checking :by_user URL parameter

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -14,8 +14,8 @@ class SubmissionsController < ApplicationController
   # GET /submissions
   # GET /submissions.xml
   def index
-    params[:by_user] = current_user.id if params[:filter] == 'my'
-    if !params[:by_user].nil? && params[:by_user] != current_user.id
+    params[:by_user] = current_user.id.to_s if params[:filter] == 'my'
+    if !params[:by_user].nil? && params[:by_user].to_i != current_user.id
       authorize User.find(params[:by_user]), :inspect?
     end
     authorize Submission.new, :show? if params[:by_user].nil?

--- a/app/views/submissions/_page.html.erb
+++ b/app/views/submissions/_page.html.erb
@@ -1,6 +1,6 @@
 <%= will_paginate @submissions %>
 <% if @submissions.length == 0 %>
-  <% if current_user.id == params[:by_user] %>
+  <% if current_user.id == params[:by_user].to_i %>
     You have no submissions.
   <% else %>
     No submissions found.

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.id.to_s == params[:by_user] %>
+<% if current_user.id == params[:by_user].to_i %>
   <% content_for :title, "My submissions" %>
 <% else %>
   <% content_for :title, "Submissions" %>


### PR DESCRIPTION
params[:by_user] is usually a string, which will never compare equal to current_user.id (an integer).

The main effect is that non-staff users weren't authorized to view /submissions/by_user/:user_id/by_problem/:problem_id even when :user_id was their own ID. Also, some of the UI messages were wrong (e.g. "No submissions found" instead of "You have no submissions").

Use params[:by_user].to_i when comparing to current_user.id.

(Note: `params[:by_user] == current_user.id.to_s` almost works but can produce incorrect results if params[:by_user] has leading zeros.)

Also, store a string in params[:by_user] when the route is /submissions/my for consistency.