### PR TITLE
Refactor logic for hiding scores below median

### DIFF
--- a/app/views/contests/scoreboard.html.erb
+++ b/app/views/contests/scoreboard.html.erb
@@ -39,7 +39,7 @@
       <% rank = 1 %>
       <% previous_record = @scoreboard.first %>
       <% @scoreboard.each_with_index do |record,index| %>
-        <% if !user_signed_in? or !(record.user && record.user.id == current_user.id) && !policy(@contest).inspect? %>
+        <% unless user_signed_in? && ((record.user && record.user.id == current_user.id) || policy(@contest).inspect?) %>
           <% next if record.score < median.score || (record.score == median.score && record.time_taken > median.time_taken) # no permission to view %>
         <% end %>
         <tr <% if user_signed_in? && record.id==current_user.id %> class="emphasized"<% end %>>


### PR DESCRIPTION
Depends on #117.
No change in behaviour.
(May soon become obsolete because #103 proposes to show all scores, but I'd like to do this refactoring anyway)

Previous: IF not-signed-in OR (not-row-of-current-user AND not-admin) THEN hide
Proposed: UNLESS signed-in AND (row-of-current-user OR admin) THEN hide

In other words, the row of the currently signed-in user is always shown, and admins always see the full scoreboard.

(Regarding review: This branch will need to be updated after #117 is merged to resolve conflicts, and that will dismiss reviews. So may as well wait until then before approving.)