### PR TITLE
Hide fields on reg and profile pages for non-NZers

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -139,8 +139,30 @@ $(document).ready(function() {
     
   });
 
+  function on_country_change() {
+    if ($("#user_country_code option:selected").text() === "New Zealand") {
+      $(".nzonly").show();
+    } else {
+      // reset jsdisplay for "Add new school"
+      $(".jsdisplay").show().prop('disabled', false);
+      $(".jsnodisplay").hide().prop('disabled', true);
+
+      // set defaults for non-NZ users
+      $("#user_school_id").val(''); // select no school
+      $("#user_school_graduation_enabled_false").prop("checked", true); // select unspecified grad date
+
+      $(".nzonly").hide();
+    }
+  }
+
   $(".jsdisplay").show().prop('disabled', false);
   $(".jsnodisplay").hide().prop('disabled', true);
+
+  // Hide the school fields if not from NZ, on user edit and registration pages
+  if ($("#user_country_code").length) {
+    on_country_change();
+    $("#user_country_code").on('change', on_country_change);
+  }
 
   $(".countdown").each(function() {
     var finalDate, format = $(this).data('format');

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ActiveRecord::Base
   validates :name, :length => {:maximum => 100, :minimum => 2}
   validates :username, :length => { :in => 2..32 }, :format => { :with => /\A\w(\.?\w)*\z/, :message => "Only letters, numbers, underscores or non-adjacent dots allowed in username" }, :presence => true, :uniqueness => { :case_sensitive => false }
   validates :avatar, :file_size => { :maximum => 40.kilobytes.to_i }
+  validates :school, :absence => { message: "must be blank if outside New Zealand"}, if: -> {country_code != "NZ"}
 
   before_save do
     self.can_change_username = false if self.username_changed? # can only change username once

--- a/app/views/accounts/registrations/new.html.erb
+++ b/app/views/accounts/registrations/new.html.erb
@@ -38,8 +38,8 @@
     <%= f.country_select(:country_code, selected: @user.country_code || request.location.try(:country_code), priority_countries: ["NZ", "AU"]) %>
   </div>
 
-  <div class="field">
-    <h3><%= f.label :school_graduation, "School Graduation (NZ Only)" %></h3>
+  <div class="field nzonly">
+    <h3><%= f.label :school_graduation, "School Graduation" %></h3>
     <p>If you attend a primary, intermediate, or secondary school (or equivalent) in New Zealand then we ask that you please enter your estimated graduation date (the month and year you expect to finish secondary school by). You can update this later if it changes. Our website uses your graduation date to calculate your eligibility to:</p>
     <ul>
       <li>Compete <i>officially</i> in the New Zealand Informatics Competition (NZIC).</li>
@@ -58,8 +58,8 @@
     <% end %>
   </div>
 
-  <div class="field">
-    <h3><%= f.label :school, "School (NZ Only)" %></h3>
+  <div class="field nzonly">
+    <h3><%= f.label :school %></h3>
     <%= f.fields_for :school, @user.school do |school_form| %>
       <%= school_form.text_field :name, class: [:school_select, :jsnodisplay] %>
       <%= f.select :school_id, School.where(country_code: "NZ").order(:name).collect {|s| [s.name, s.id]}, { include_blank: true }, class: [:school_select, :jsdisplay], disabled: true %><br />

--- a/app/views/accounts/settings/edit.html.erb
+++ b/app/views/accounts/settings/edit.html.erb
@@ -42,8 +42,8 @@
     <%= f.country_select(:country_code, priority_countries: ["NZ", "AU"] ) %>
   </div>
 
-  <div class="field">
-    <h3><%= f.label :school_graduation, "School Graduation (NZ Only)" %></h3>
+  <div class="field nzonly">
+    <h3><%= f.label :school_graduation, "School Graduation" %></h3>
     <p>If you attend a primary, intermediate, or secondary school (or equivalent) in New Zealand then we ask that you please enter your estimated graduation date (the month and year you expect to finish secondary school by). You can update this later if it changes. Our website uses your graduation date to calculate your eligibility to:</p>
     <ul>
       <li>Compete <i>officially</i> in the New Zealand Informatics Competition (NZIC).</li>
@@ -62,8 +62,8 @@
     <% end %>
   </div>
 
-  <div class="field">
-    <h3><%= f.label :school, "School (NZ Only)" %></h3>
+  <div class="field nzonly">
+    <h3><%= f.label :school %></h3>
     <%= f.fields_for :school, @user.school do |school_form| %>
       <%= school_form.text_field :name, class: [:school_select, :jsnodisplay] %>
       <%= f.select :school_id, School.where(country_code: "NZ").order(:name).collect {|s| [s.name, s.id]}, { include_blank: true }, class: [:school_select, :jsdisplay], disabled: true %><br />


### PR DESCRIPTION
Add javascript that 'disables' graduation date and school fields for non-NZers.

Graduation date checks not reinforced server side but no major issues are forseen.

Requires PR #128 <strike>which requires PR #125</strike>