### PR TITLE
Disable async loading of JavaScript in production mode

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
       <link rel="shortcut icon" href="/favicon.ico">
       <%= stylesheet_link_tag "application" %>
-      <%= javascript_include_tag "application", :async => Rails.env.production? %>
+      <%= javascript_include_tag "application", :async => false %>
       <%= javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.1.0/MathJax.js?config=TeX-AMS_HTML", :async => true %>
       <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Ubuntu:400italic,Ubuntu:400"%>
       <noscript><style type="text/css">.js_only { display: none; }</style></noscript>


### PR DESCRIPTION
The async attribute seems to delay execution of scripts, even if they are cached.

This can cause some page elements to flash on load:
 - The left sidebar (if minimised)
 - Dropdown menu arrows
 - The school fields, if the user's country is not set to NZ (in #129)
 
In production mode, the application scripts are concatenated into a single file (currently about 290 KB), and it will typically be cached, so I don't think async is necessary.