### PR TITLE
Expose more data over the API

### DIFF
--- a/app/controllers/accounts/requests_controller.rb
+++ b/app/controllers/accounts/requests_controller.rb
@@ -6,5 +6,16 @@ class Accounts::RequestsController < ApplicationController
   def index
     @pending_requests = current_user.requests.pending
     @requests = current_user.requests.closed
+
+    respond_to do |format|
+      format.html
+
+      # Return all requests in the XML, sorted by creation date
+      format.xml {
+        render :xml => (@pending_requests + @requests).sort do |a, b|
+          a.created_at <=> b.created_at
+        end
+      }
+    end
   end
 end

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -1,3 +1,5 @@
+require 'builder'
+
 class ContestsController < ApplicationController
   def permitted_params
     @_permitted_params ||= begin
@@ -18,7 +20,7 @@ class ContestsController < ApplicationController
       authorize Contest.new, :manage?
       @contests = Contest.order("end_time DESC")
     end
-    
+
     respond_to do |format|
       format.html # index.html.erb
     end
@@ -42,6 +44,11 @@ class ContestsController < ApplicationController
     else
       raise Pundit::NotAuthorizedError
     end
+
+    respond_to do |format|
+      format.html
+      format.xml { render :xml => @contests.to_xml(:user => current_user) }
+    end
   end
 
   # GET /contests/1
@@ -61,7 +68,10 @@ class ContestsController < ApplicationController
       @contest_message = "You have not started this contest."
     end
 
-    render :layout => 'contest'
+    respond_to do |format|
+      format.html { render :layout => 'contest' }
+      format.xml { render :xml => @contest.to_xml(:user => current_user) }
+    end
   end
 
   def info

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -59,7 +59,10 @@ class GroupsController < ApplicationController
     @group = Group.find(params[:id])
     if policy(@group).access?
       @problem_set_associations = @group.problem_set_associations
-      render :layout => "group"
+      respond_to do |format|
+        format.html { render :layout => "group" }
+        format.xml { render :xml => @group }
+      end
     else
       redirect_to info_group_path(@group)
     end
@@ -73,8 +76,8 @@ class GroupsController < ApplicationController
       format.html { render :layout => "group" }
     end
   end
-  
-  def info 
+
+  def info
     @group = Group.find(params[:id])
     authorize @group, :show?
     respond_to do |format|

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -73,6 +73,7 @@ class ProblemsController < ApplicationController
 
     respond_to do |format|
       format.html { render :layout => "problem" }
+      format.xml { render :xml => @problem }
     end
 
     if user_signed_in?
@@ -115,7 +116,7 @@ class ProblemsController < ApplicationController
       start_time = current_user.contest_relations.joins(:contest => {:problem_set => :problems}).where{(started_at <= DateTime.now) & (finish_at > DateTime.now) & (contest.problem_set.problems.id == my{params[:id]})}.minimum(:started_at)
       @submissions = @problem.submission_history(current_user,start_time)
     end
-    
+
     respond_to do |format|
       format.html { render :layout => "problem" }
     end
@@ -225,7 +226,7 @@ class ProblemsController < ApplicationController
   def update
     @problem = Problem.find(params[:id])
     authorize @problem, :update?
-    
+
     @problem.assign_attributes(permitted_params)
     respond_to do |format|
       if validate(@problem) && @problem.save

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -50,6 +50,7 @@ class ProblemsController < ApplicationController
 
     respond_to do |format|
       format.html # index.html.erb
+      format.xml { render :xml => @problems }
     end
   end
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -21,13 +21,13 @@ class UserController < ApplicationController
   def show
     @user = User.find(params[:id])
     authorize @user, :show?
-    @solved_problems = @user.user_problem_relations.where(ranked_score: 100).joins(:problem).select([:problem_id, :ranked_submission_id, {problem: :name}]).order("problems.name")
+    @solved_problems = @user.solved_problems
 
     @user_presenter = UserPresenter.new(@user).permit!(*visible_attributes)
 
     respond_to do |format|
       format.html
-      format.xml {render :xml => @user }
+      format.xml {render :xml => @user, :user => current_user }
     end
   end
 

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -167,8 +167,9 @@ class Contest < ActiveRecord::Base
   end
 
   def to_xml(opts={})
-    super(opts) do |xml|
+    opts[:exclude] ||= [:startcode]
 
+    super(opts) do |xml|
       if opts[:user] then
         policy = Pundit.policy(opts[:user], self)
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -54,5 +54,30 @@ class Group < ActiveRecord::Base
   def invite!(user, current_user)
     Request.create(:requester => current_user, :subject => self, :verb => :invite, :target => user, :requestee => user)
   end
+
+  def to_xml(opts={})
+    # No sensitive data
+    super(opts) do |xml|
+      xml.contests 'count' => contests.count do
+        contests.each do |contest|
+          ActiveSupport::XmlMini.to_tag(
+            'id',
+            contest.id,
+            {:builder => xml},
+          )
+        end
+      end
+
+      xml.problem_sets 'count' => problem_sets.count do
+        problem_sets.each do |problem_set|
+          ActiveSupport::XmlMini.to_tag(
+            'id',
+            problem_set.id,
+            {:builder => xml},
+          )
+        end
+      end
+    end
+  end
 end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -58,25 +58,8 @@ class Group < ActiveRecord::Base
   def to_xml(opts={})
     # No sensitive data
     super(opts) do |xml|
-      xml.contests 'count' => contests.count do
-        contests.each do |contest|
-          ActiveSupport::XmlMini.to_tag(
-            'id',
-            contest.id,
-            {:builder => xml},
-          )
-        end
-      end
-
-      xml.problem_sets 'count' => problem_sets.count do
-        problem_sets.each do |problem_set|
-          ActiveSupport::XmlMini.to_tag(
-            'id',
-            problem_set.id,
-            {:builder => xml},
-          )
-        end
-      end
+      XmlUtil.serialize_id_list xml, 'contests', contests
+      XmlUtil.serialize_id_list xml, 'problem-sets', problem_sets
     end
   end
 end

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -110,10 +110,18 @@ class Problem < ActiveRecord::Base
   end
 
   def to_xml(opts={})
+    # hide e.g. test submission stats
+    opts[:only] ||= [:id, :name, :statement, :input, :output, :memory_limit, :time_limit, :owner_id, :created_at, :updated_at]
+
     super(opts) do |xml|
       XmlUtil.serialize_id_list xml, 'contests', contests
       XmlUtil.serialize_id_list xml, 'groups', groups
       XmlUtil.serialize_id_list xml, 'problem-sets', problem_sets
+
+      XmlUtil.serialize_list xml, 'sample-cases', sample_cases do |sample|
+        XmlUtil.tag xml, 'input', sample.input
+        XmlUtil.tag xml, 'output', sample.output
+      end
 
       # TODO: Possibly nice to include submission ids here if user is an admin?
     end

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -72,7 +72,7 @@ class Problem < ActiveRecord::Base
   def get_score(user, from = DateTime.new(1), to = DateTime.now)
     subs = self.submissions.find(:all, :limit => 1, :order => "score DESC", :conditions => ["created_at between ? and ? and user_id = ?", from, to, user])
     scores = subs.map {|s| s.score}
-    return scores.max 
+    return scores.max
   end
 
   def submission_history(user, from = DateTime.new(1), to = DateTime.now)
@@ -107,5 +107,15 @@ class Problem < ActiveRecord::Base
   def weighted_score
     return nil if self.points.nil?
     self.points * self.weighting / self.maximum_points
+  end
+
+  def to_xml(opts={})
+    super(opts) do |xml|
+      XmlUtil.serialize_id_list xml, 'contests', contests
+      XmlUtil.serialize_id_list xml, 'groups', groups
+      XmlUtil.serialize_id_list xml, 'problem-sets', problem_sets
+
+      # TODO: Possibly nice to include submission ids here if user is an admin?
+    end
   end
 end

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -119,8 +119,10 @@ class Problem < ActiveRecord::Base
       XmlUtil.serialize_id_list xml, 'problem-sets', problem_sets
 
       XmlUtil.serialize_list xml, 'sample-cases', sample_cases do |sample|
-        XmlUtil.tag xml, 'input', sample.input
-        XmlUtil.tag xml, 'output', sample.output
+        xml.tag! 'sample-case' do
+          XmlUtil.tag xml, 'input', sample.input
+          XmlUtil.tag xml, 'output', sample.output
+        end
       end
 
       # TODO: Possibly nice to include submission ids here if user is an admin?

--- a/app/models/problem_set.rb
+++ b/app/models/problem_set.rb
@@ -41,6 +41,8 @@ class ProblemSet < ActiveRecord::Base
     opts[:only] ||= [:id, :name, :owner_id, :created_at, :updated_at]
 
     super(opts) do |xml|
+      XmlUtil.serialize_id_list xml, 'contests', contests
+      XmlUtil.serialize_id_list xml, 'groups', groups
       XmlUtil.serialize_id_list xml, 'problems', problems
     end
   end

--- a/app/models/problem_set.rb
+++ b/app/models/problem_set.rb
@@ -41,15 +41,7 @@ class ProblemSet < ActiveRecord::Base
     opts[:only] ||= [:id, :name, :owner_id, :created_at, :updated_at]
 
     super(opts) do |xml|
-      xml.problems do
-        problems.each do |problem|
-          ActiveSuppoprt::XmlMini.to_tag(
-            'id',
-            problem.id,
-            {:builder => xml},
-          )
-        end
-      end
+      XmlUtil.serialize_id_list xml, 'problems', problems
     end
   end
 end

--- a/app/models/problem_set.rb
+++ b/app/models/problem_set.rb
@@ -43,7 +43,11 @@ class ProblemSet < ActiveRecord::Base
     super(opts) do |xml|
       xml.problems do
         problems.each do |problem|
-          xml.tag!('id', problem.id, :type => ActiveSupport::XmlMini::TYPE_NAMES[problem.id.class.name])
+          ActiveSuppoprt::XmlMini.to_tag(
+            'id',
+            problem.id,
+            {:builder => xml},
+          )
         end
       end
     end

--- a/app/models/problem_set.rb
+++ b/app/models/problem_set.rb
@@ -36,4 +36,16 @@ class ProblemSet < ActiveRecord::Base
   def total_weighting
     problem_associations.sum(:weighting)
   end
+
+  def to_xml(opts={})
+    opts[:only] ||= [:id, :name, :owner_id, :created_at, :updated_at]
+
+    super(opts) do |xml|
+      xml.problems do
+        problems.each do |problem|
+          xml.tag!('id', problem.id, :type => ActiveSupport::XmlMini::TYPE_NAMES[problem.id.class.name])
+        end
+      end
+    end
+  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,6 +1,6 @@
 class Request < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
-  
+
   belongs_to :requester, :class_name => :User # entity that initiated request
   belongs_to :subject, :polymorphic => true # subject controlled by requester
   # verb # action applying subject to target
@@ -41,5 +41,19 @@ class Request < ActiveRecord::Base
   def cancel!
     self.status = STATUS[:cancelled]
     self.save
+  end
+
+  def to_xml(opts={})
+    if self.expired_at == Float::INFINITY then
+      # `expired_at` has the value Float::INFINITY when the request hasn't expired,
+      # and the XML formatter explodes when it encounters that value. Adding :expired_at
+      # to opts[:exclude] is the obvious solution, but for reasons unknown to me it does
+      # not appear to work as expected. Changing `expired_at` to some other value (which isn't
+      # a datetime) will result in an empty tag being emitted with a `nil="true"` attribute
+      # which seems like the best solution after just omitting the tag entirely.`
+      self.expired_at = 0
+    end
+
+    super(opts)
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -201,7 +201,7 @@ class Submission < ActiveRecord::Base
 
   def to_xml(opts={})
     # hiding e.g. judge log
-    opts[:only] ||= [:id, :source, :score, :user_id, :problem_id, :created_at, :updated_at, :input, :output, :language_id, :judged_at, :evaluation, :points, :maximum_points]
+    opts[:only] ||= [:id, :source, :score, :user_id, :problem_id, :created_at, :updated_at, :input, :output, :language_id, :judged_at, :evaluation]
 
     super(opts)
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,6 +1,6 @@
 class Submission < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
-  
+
   belongs_to :user
   belongs_to :problem
   has_many :contest_scores
@@ -9,7 +9,7 @@ class Submission < ActiveRecord::Base
   def user_problem_relation
     UserProblemRelation.where(:user_id => user_id, :problem_id => problem_id).first_or_create!
   end
-  
+
   validates :source, :presence => true
   validate do |submission|
     errors.add :language_id, "Invalid language specified" if submission.language.nil?
@@ -199,5 +199,11 @@ class Submission < ActiveRecord::Base
     end
   end
 
+  def to_xml(opts={})
+    # hiding e.g. judge log
+    opts[:only] ||= [:id, :source, :score, :user_id, :problem_id, :created_at, :updated_at, :input, :output, :language_id, :judged_at, :evaluation, :points, :maximum_points]
+
+    super(opts)
+  end
 end
 

--- a/app/services/xml_util.rb
+++ b/app/services/xml_util.rb
@@ -1,15 +1,21 @@
 module XmlUtil
+  def self.serialize_list builder, name, docs
+    array_type = ActiveSupport::XmlMini::TYPE_NAMES['Array']
+    builder.tag!(name, 'count' => docs.count, 'type' => array_type) do
+      docs.each do |doc| yield doc end
+    end
+  end
+
   def self.serialize_id_list builder, name, docs
     array_type = ActiveSupport::XmlMini::TYPE_NAMES['Array']
 
-    builder.tag!(name, 'count' => docs.count, 'type' => array_type) do
-      docs.each do |doc|
-        ActiveSupport::XmlMini.to_tag(
-          'id',
-          doc.id,
-          {:builder => builder},
-        )
-      end
+    XmlUtil.serialize_list builder, name, docs do |doc|
+      XmlUtil.tag builder, 'id', doc.id
     end
+  end
+
+  # Wrapper around ActiveSupport's to_tag method as the original is pretty long
+  def self.tag builder, name, value
+    ActiveSupport::XmlMini.to_tag(name, value, {:builder => builder})
   end
 end

--- a/app/services/xml_util.rb
+++ b/app/services/xml_util.rb
@@ -1,6 +1,8 @@
 module XmlUtil
   def self.serialize_id_list builder, name, docs
-    builder.tag!(name, 'count' => docs.count) do
+    array_type = ActiveSupport::XmlMini::TYPE_NAMES['Array']
+
+    builder.tag!(name, 'count' => docs.count, 'type' => array_type) do
       docs.each do |doc|
         ActiveSupport::XmlMini.to_tag(
           'id',

--- a/app/services/xml_util.rb
+++ b/app/services/xml_util.rb
@@ -1,0 +1,13 @@
+module XmlUtil
+  def self.serialize_id_list builder, name, docs
+    builder.tag!(name, 'count' => docs.count) do
+      docs.each do |doc|
+        ActiveSupport::XmlMini.to_tag(
+          'id',
+          doc.id,
+          {:builder => builder},
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Exposes additional API endpoints (e.g. `GET /problems/:id.xml`), adds additional data to some endpoints (e.g. `<groups>` node when retrieving a `ProblemSet`), and hides some sensitive info such as the judge log when retrieving submissions.

# Serializers

Serialization logic has been implemented by overriding the `to_xml` method of the relevant models which avoids the need to repeat `:only` and `:include` all over the place. Ideally we'd want this logic separated out into serializer classes, but I couldn't figure out an elegant way of doing that.

Some things I tried:

* The `active_model_serializers` gem does not support XML, and while the authors are interested in adding support they're only looking into it for version 0.10 which requires Rails 6. Train runs on Rails 4 and I imagine bumping by 2 major versions will break things (see: https://github.com/rails-api/active_model_serializers/pull/448#issuecomment-53111258)
* `ActiveModel::Serializers::XML` is, afaict, built-in to Rails 4 (it was split out in v5?) and so isn't very helpful
* A custom *Serializer class doesn't seem to work the way I'd expect it to (I've tried both returning yielding a `Builder::MarkupXml` and wind up with strange extraneous elements inserted)
* The `serializable_hash` method feels a bit nicer to override than `to_xml`, but doesn't receive all of the builder options (`:include` is missing, for instance)
* An `attributes` method results in pretty strange XML, see the `total-weighting` element here: https://i.imgur.com/w0zsVTj.png

If there's a better place for the serialization logic or a library you know of, I'm happy to rework the PR. Ruby isn't my area of expertise :)

The stock `to_xml` behavior adds `type` attributes to nodes, but if you manually add a tag through a builder you don't get that attribute. `XmlUtil` exists mainly to ergonomically add `type` attributes to custom nodes in order to maintain consistency with the rest of the XML doc.

Swapping over to JSON could be an idea, as it would let us use `active_model_serializers`. JSON also handles whitespace perfectly, whereas with XML it's possible to configure your parser to strip out extraneous whitepsace -- which is a problem when working with submissions. This felt like a pretty major change though so I didn't do it.

# Didn't do

A few things mentioned on Discord haven't been done:

* Filtering out comments from problem statements; I'm not sure how to accomplish that using the built-in XML serializer.
* Hiding `updated-at`: `updated-at` works great as a cache key and I can't see any issue with exposing it -- so it's still visible.
* It was mentioned to hide `name` on `User` docs; I've set it up so that if you hit the API from a staff account you get the user's name (and email), but otherwise those fields don't exist. This mirrors the behavior of the HTML page.

# Future

* None of these endpoints are paginated; I'm assuming this isn't an issue given Tom's comment re HTTP requests
* Swapping to JSON might be a good idea as it seems like there's more tooling available in the Rails ecosystem

Here are some endpoints which I haven't included in this PR, but would like to have done eventually (eventually probably meaning never -- parsing the HTML feels easier than writing the serializers):

* Including scoreboard data in `GET /contests/:id.xml`. There are a lot of moving parts to that code and I'm not entirely sure I understand all the acl rules.
* It would also be nice to have the parsed judge data inlined in inside `GET /submissions/:id.xml` as _most_ of the info is available through the web interface anyway, but I didn't do that either as I think there's room for discussion about the exact shape of the XML and it's also fairly straightforward to parse out judge results from the HTML, anyway. Here's where I got up to before deciding it was getting too big: https://i.imgur.com/ibclHnr.png

# XML Samples

Here are some sample XML docs (note that `problems` in the contest sample is collapsed in the UI; the contest `startcode` is now censored, and `points`+`max-points` are also excluded from submissions now): https://imgur.com/a/UfJs203