### PR TITLE
Hotfix: Deliver emails to a Discord channel using a webhook

### DIFF
--- a/app/views/accounts/registrations/new.html.erb
+++ b/app/views/accounts/registrations/new.html.erb
@@ -6,7 +6,7 @@
   <li>Access more problems.</li>
 </ul>
 
-<p><strong>Note:</strong> Due to a technical issue, confirmation emails for new accounts currently need to be sent manually by staff.</p>
+<p><strong>Note:</strong> Due to a technical issue, confirmation emails for new accounts are currently sent manually by staff and may take a day or so to arrive.</p>
 
 <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name)) do |f| %>
   <%= devise_error_messages! %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<p><strong>Note:</strong> Due to a technical issue, password reset emails are currently sent manually by staff.</p>
+<p><strong>Note:</strong> Due to a technical issue, password reset emails are currently sent manually by staff and may take a day or so to arrive.</p>
 
 <%= simple_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f| %>
   <%= f.error_notification %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,8 +41,9 @@ NZTrain::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
-  # Mail delivery is currently broken, so as a temporary workaround we save the email to a file and send it manually.
-  config.action_mailer.delivery_method = :file
+  # Mail delivery using SMTP is currently broken, so as a temporary workaround
+  # we send the emails to Discord using a webhook and then email them manually.
+  config.action_mailer.delivery_method = WebhookMailDelivery
 
   # Enable threaded mode
   # config.threadsafe!

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -15,7 +15,7 @@ en:
     failure:
       already_authenticated: 'You are already signed in.'
       unauthenticated: 'You need to sign in or sign up before continuing.'
-      unconfirmed: 'You have to confirm your account before continuing. Please contact staff@nzoi.org.nz and we''ll send you the confirmation link.'
+      unconfirmed: 'You have to confirm your account before continuing. Please contact staff@nzoi.org.nz if you didn''t receive the confirmation email and it''s been more than a day since you registered.'
       locked: 'Your account is locked.'
       not_found_in_database: 'Invalid email or password.'
       invalid: 'Invalid email or password.'
@@ -26,16 +26,16 @@ en:
       signed_in: 'Signed in successfully.'
       signed_out: 'Signed out successfully.'
     passwords:
-      send_instructions: 'Please contact staff@nzoi.org.nz and we''ll send you the link to reset your password.'
+      send_instructions: 'You will receive an email with instructions about how to reset your password within the next day or so. Please contact staff@nzoi.org.nz if you don''t receive the email.'
       updated: 'Your password was changed successfully. You are now signed in.'
       send_paranoid_instructions: "If your e-mail exists on our database, you will receive a password recovery link on your e-mail"
     confirmations:
-      send_instructions: 'Please contact staff@nzoi.org.nz and we''ll send you the confirmation link.'
+      send_instructions: 'You will receive an email with instructions about how to confirm your account within the next day or so. Please contact staff@nzoi.org.nz if you don''t receive the email.'
       send_paranoid_instructions: 'If your e-mail exists on our database, you will receive an email with instructions about how to confirm your account in a few minutes.'
       confirmed: 'Your account was successfully confirmed. You are now signed in.'
     registrations:
       signed_up: 'Welcome! You have signed up successfully.'
-      signed_up_but_unconfirmed: 'To confirm your account, please contact staff@nzoi.org.nz and we''ll send you a confirmation link.'
+      signed_up_but_unconfirmed: 'A message with a confirmation link will be sent to your email address within the next day or so. Please contact staff@nzoi.org.nz if you don''t receive the email.'
       signed_up_but_inactive: 'You have signed up successfully. However, we could not sign you in because your account is not yet activated.'
       signed_up_but_locked: 'You have signed up successfully. However, we could not sign you in because your account is locked.'
       updated: 'You updated your account successfully.'

--- a/lib/webhook_mail_delivery.rb
+++ b/lib/webhook_mail_delivery.rb
@@ -1,0 +1,60 @@
+require 'uri'
+require 'net/http'
+require 'nokogiri'
+
+# WebhookMailDelivery posts emails using a webhook, e.g. to a Discord channel.
+#
+# It allows staff to then manually send the email, which is useful when regular
+# delivery using SMTP is broken.
+#
+# Special characters in the message are backslash-escaped (this is suitable for
+# destinations that render using Markdown-like syntax, such as Discord).
+class WebhookMailDelivery
+  attr_accessor :settings
+
+  def initialize(values)
+    self.settings = values
+  end
+
+  def deliver!(mail)
+    body_html = mail.body.decoded
+    body_text = html_to_plain_text(body_html)
+    body_text = body_text.rstrip + "\n.\n" # add a visual separator between messages
+    body_escaped = escape_message_for_markdown(body_text)
+    post_webhook "To: #{mail.to.join(' ')}\nSubject: #{mail.subject}\n\n#{body_escaped}"
+  end
+
+  def html_to_plain_text(html)
+    # convert links to plain text
+    # e.g. '<a href="https://...">Click here</a>' becomes 'Click here: https://...'
+    html = html.gsub(/<a href="([^"]*)">([^<]*)<\/a>/, '\2: \1')
+    # strip remaining HTML tags
+    Nokogiri::HTML(html).text
+  end
+
+  def escape_message_for_markdown(text)
+    # replace non-ASCII characters with "?"
+    text = text.encode('ascii', :undef => :replace, :invalid => :replace)
+    # replace control characters (other than newline, \x0A) with "?"
+    text = text.gsub(/[\x00-\x09\x0B-\x1F\x7F]/, '?')
+    # backslash-escape all characters except those known to be safe (very conservative)
+    text = text.gsub(/[^A-Za-z0-9_ \n]/) {|s| '\\' + s}
+    text
+  end
+
+  def post_webhook(content)
+    uri = URI(Setting.find_by_key("system/mailer/webhook").value)
+    data = { "content" => content }
+    request = Net::HTTP::Post.new(uri)
+    request.body = data.to_json
+    request["Content-Type"] = "application/json"
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+      response = http.request(request)
+      Rails.logger.info "Webhook response status: #{response.inspect}"
+      if !response.is_a?(Net::HTTPSuccess)
+        Rails.logger.error "Webhook response body: #{response.body.inspect}"
+        response.value # to raise an HTTP error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Improved workaround for #144.

I deployed the initial workaround directly (branch 'hotfix-email', [commits](https://github.com/NZOI/nztrain/compare/743679784bebc5bc2a37e7e10d83bef6d033395d...a54b2ca6a61344cfe30c79893ed678c72efb3eb9)), but I decided to use a pull request for this improved version to give people a chance to comment, because it's a larger change and the initial workaround has bought us time.

I intend to deploy this in ~24 hours if there are no objections.

We are pretty close to enabling 2-step verification (need the right people to be online at the same time), so we could just wait a bit and not deploy this workaround.

Another option is to keep the initial workaround (file delivery) but change the instructions in the web interface to only ask students to contact staff if they don't get the email within a day (currently the instructions ask students to contact staff unconditionally). I'm happy to check the mail directory on the server at least once a day, so we can still get a reasonable response time without using Discord and without asking the students to send us an email.

---

Commit message:

> Deliver emails to a Discord channel using a webhook
> 
> This is nicer than writing the emails as files because we can receive
> notifications from Discord (so students shouldn't need to send us a
> request) and because staff will be able to view and forward the emails
> without requiring SSH access to the server.
> 
> The webhook URL can be created in Discord by opening the Server
> Settings then the Integrations tab:
> https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
> 
> This URL needs to be set in the web app using admin > settings > New
> *before* this commit is deployed. The key is "system/mailer/webhook"
> and the value is the webhook URL.
> 
> This commit also updates the messages in the interface to only ask
> students to contact staff if they don't get the email within a day.
> 
> ...

Here is a sample message:

> To: example@example.com
> Subject: Confirmation instructions
> 
> Welcome example@example.com!
> 
> You can confirm your account email through the link below:
> 
> Confirm my account: http://train.nzoi.org.nz/accounts/confirmation?confirmation_token=xxx
> .

The idea is that the staff on Discord will be notified and will manually email this message.

You can see my development history (bugfixing) in branch 'tom93/hotfix-email-v2-history' ([commits](https://github.com/NZOI/nztrain/compare/a54b2ca6a61344cfe30c79893ed678c72efb3eb9...da7af74681a9772702abedfc8ed279541658c8f3)).