### PR TITLE
Give group members access to scoreboard

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -73,8 +73,8 @@ class GroupsController < ApplicationController
       format.html { render :layout => "group" }
     end
   end
-  
-  def info 
+
+  def info
     @group = Group.find(params[:id])
     authorize @group, :show?
     respond_to do |format|
@@ -84,7 +84,7 @@ class GroupsController < ApplicationController
 
   def scoreboard
     @group = Group.find(params[:id])
-    authorize @group, :inspect?
+    authorize @group, :access?
     @problem_set_associations = @group.problem_set_associations
 
     problem_ids = ProblemSetProblem.where(:problem_set_id => GroupProblemSet.where(:group_id => @group.id).select(:problem_set_id)).select(:problem_id)

--- a/app/views/groups/scoreboard.html.erb
+++ b/app/views/groups/scoreboard.html.erb
@@ -26,13 +26,19 @@
             <% problem = problem_association.problem %>
             <% weight = problem_association.weighting %>
             <% relation = @scores[member.id][problem.id] %>
+            <% if policy(@group).inspect? %>
+              <% viewed = relation.try(:last_viewed_at) %>
+            <% else %>
+              <% # pretend the user viewed the problem, to avoid indicating to other group members whether the user viewed it %>
+              <% viewed = true %>
+            <% end %>
             <td class="tight">
-              <% if relation.try(:last_viewed_at) %>
+              <% if viewed %>
                 <%= progress_bar(relation.try(:submission).try(:weighted_score, weight), weight, relation.try(:submission), size: :compact) %>
               <% end %>
             </td>
             <td class="tight" style="text-align: right;padding-left:5px;padding-right:5px;">
-              <% if policy(@group).inspect? && relation.try(:last_viewed_at) %>
+              <% if policy(@group).inspect? && viewed %>
                 (<%= link_to((relation.try(:submissions_count) || 0), :controller => "submissions", :by_user => member, :by_problem => problem) %>)
               <% end %>
             </td>

--- a/app/views/groups/scoreboard.html.erb
+++ b/app/views/groups/scoreboard.html.erb
@@ -32,7 +32,7 @@
               <% end %>
             </td>
             <td class="tight" style="text-align: right;padding-left:5px;padding-right:5px;">
-              <% if relation.try(:last_viewed_at) %>
+              <% if policy(@group).inspect? && relation.try(:last_viewed_at) %>
                 (<%= link_to((relation.try(:submissions_count) || 0), :controller => "submissions", :by_user => member, :by_problem => problem) %>)
               <% end %>
             </td>

--- a/app/views/layouts/group.html.erb
+++ b/app/views/layouts/group.html.erb
@@ -24,7 +24,7 @@
     menu.item :files, "files", group_files_path(@group) if policy(@group).update? || (@group.filelinks.any? && policy(@group).access?)
     menu.item :contests, "contests", contests_group_path(@group) if policy(@group).access?
     menu.item :members, "members", members_group_path(@group), :highlights_on => %r(#{members_group_path(@group)}) if policy(@group).access?
-    menu.item :scoreboard, "scoreboard", scoreboard_group_path(@group) if policy(@group).inspect?
+    menu.item :scoreboard, "scoreboard", scoreboard_group_path(@group) if policy(@group).access?
 #  end.render
   end
   %>


### PR DESCRIPTION
It was discussed at the AGM that it would be motivating for the training squad to see the progress of their pairs. Admins have access to a scoreboard which offers exactly this. This pull request seeks to give group members permission to see the group scoreboard.

* These changes are untested (I don't have a VM setup to do that).
* This means all members of a group can see the progress of all other members in that group. This would apply to all groups.

Would be grateful if someone could please review this.