### PR TITLE
Upgrade rmagick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'forem-redcarpet', github: 'NZOI/forem-redcarpet'
 
 gem "nokogiri", '~> 1.10.8'
 gem 'redcarpet'
-#gem 'rmagick', '2.13.2'
 gem 'rmagick'
 gem 'carrierwave', '0.9.0'
 gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,7 @@ GEM
       ttfunk
     pdfkit (0.8.2)
     pg (0.21.0)
+    pkg-config (1.5.1)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
     posix-spawn (0.3.13)
@@ -293,7 +294,8 @@ GEM
     render_anywhere (0.0.12)
       rails (>= 3.0.7)
     request_store (1.0.8)
-    rmagick (2.16.0)
+    rmagick (5.1.0)
+      pkg-config (~> 1.4)
     rqrcode (0.10.1)
       chunky_png (~> 1.0)
     rspec-collection_matchers (1.1.3)


### PR DESCRIPTION
This newer version workers with older system libraries (as far as I can tell) and workers with new ruby / rails versions so is a requirement for eventually upgrading Rails