### PR TITLE
Fix rvm install script by changing the OpenPGP keyserver to keyserver.ubuntu.com

### DIFF
--- a/script/install/rvm.bash
+++ b/script/install/rvm.bash
@@ -25,7 +25,7 @@ rvm --version &> /dev/null && {
   }
 
   # Import GPG signing keys (key IDs from https://rvm.io/)
-  cmd="gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
+  cmd="gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
   echo "$ $cmd"
   $cmd
 


### PR DESCRIPTION
From the commit message:

> The official installation method[1] uses
> 
>     gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys ...
> 
> However, the keyserver pool.sks-keyservers.net has been discontinued.[2]
> 
> Of the popular alternatives,
> 
>  - keys.gnupg.net is gone (it was an alias to pool.sks-keyservers.net)
>  - keys.openpgp.org doesn't have the keys of the RVM maintainers
>  - pgp.mit.edu was unreliable for me (really slow, only returns the keys some of the time)
>  - keyserver.pgp.com timed out for me
>  - keyserver.ubuntu.com works
> 
> So switch to keyserver.ubuntu.com.
> 
> (An alternative approach is to download the public keys from https://rvm.io/mpapis.asc and https://rvm.io/pkuczynski.asc as described in [3]. This method is considered less secure because it does not verify the fingerprints of the keys and relies purely on the security provided by HTTPS. But we are already relying on HTTPS for security because we currently download the install script using `curl https://get.rvm.io | bash` without verifying (see [4]), so it makes little difference.)
> 
> [1]: https://web.archive.org/web/20220606211058/http://rvm.io/rvm/security
> [2]: https://web.archive.org/web/20220119094712/https://www.sks-keyservers.net/
> [3]: https://rvm.io/rvm/security#alternatives
> [4]: https://rvm.io/rvm/security#run-verified-installation