### PR TITLE
Temporarily lock the Redis version to 6.2.6 to fix qless error

### DIFF
--- a/script/install/redis.bash
+++ b/script/install/redis.bash
@@ -19,7 +19,10 @@ redis-server --version 2>/dev/null | bash script/extract_version.bash | bash scr
   apt-get install chkconfig
 
   # install redis
-  bash "`dirname $0`/redis-installer.bash"
+  # version temporarily locked to 6.2.6, because 7.0+ and 6.2.7+ break qless
+  # see https://github.com/seomoz/qless-core/issues/89
+  # TODO: once that issue is fixed, "--version ..." can be removed to switch back to "stable"
+  bash "`dirname $0`/redis-installer.bash" --version 6.2.6
   result=$?
 
   if [[ "$result" -eq 0 ]] ; then


### PR DESCRIPTION
From the commit message:

> Redis 7.0 (the current stable) and 6.2.7+ break qless, see https://www.github.com/seomoz/qless-core/issues/89.
> 
> Lock the version to 6.2.6 until that issue is fixed.
>
> ...

---

I submitted a PR to qless that fixes the bug ([seomoz/qless-core#90](https://www.github.com/seomoz/qless-core/pull/90)) in July 2022 ~~but there has been no response~~. I pinged them again just now in the main repo ([seomoz/qless#297](https://www.github.com/seomoz/qless/issues/297)), I hope ~~they'll finally apply the patch so~~ we don't end up stuck on an unsupported Redis version. (Worst case we can fork qless.)

EDIT: I've just realised they did try to merge my patch but had to revert it due to build errors: https://github.com/seomoz/qless-core/commit/49f707402b7f53006d0696cb49ae5baaa0535b44. I'm not sure what the error is (I still offered to try to help).

UPDATE: One user said that they <!-- https://github.com/community/community/discussions/23123 -->[consider qless to be abandoned](https://www.github.com/seomoz/qless-core/pull/85#issuecomment-1246051175). We might have to fork it after all, and maybe eventually replace it with something else... Before qless we used sideqik (https://github.com/NZOI/nztrain/commit/41c03f63ee4c8a1d98c2159ef194ebe115b62e70); here is an old comment from Ronald with some motivation: [seomoz/qless#168](https://www.github.com/seomoz/qless/issues/168).