### PR TITLE
Fix URL of rbenv-installer script

### DIFF
--- a/script/install/rbenv.bash
+++ b/script/install/rbenv.bash
@@ -29,7 +29,7 @@ rbenv --version &> /dev/null || {
   # rbenv-installer prints some instructions, make it clear what is
   # output from rbenv-installer and what is output from this script.
   echo "script/install/rbenv.bash: running rbenv-installer..."
-  curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer | bash
+  curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
   # ignore exit code because rbenv-installer runs rbenv-doctor, which is fussy and reports spurious errors
   echo "script/install/rbenv.bash: rbenv-installer finished"
   if ! [ -x ~/.rbenv/bin/rbenv ]; then


### PR DESCRIPTION
They renamed the branch from "master" to "main".[1] Their README suggests to use "HEAD" instead of hard-coding the branch name.[2]

[1]: https://github.com/rbenv/rbenv-installer/commit/e017714f3e4eba6b18c3e5c041d169df832fbb2f
[2]: https://github.com/rbenv/rbenv-installer/commit/b4e8f205dc6d47885e574dba23dba855a9f3b512