### PR TITLE
Install Bundler 1.x instead of latest version (2.4)

### DIFF
--- a/script/install/bundler.bash
+++ b/script/install/bundler.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-bundler_version="<2.4" # must be < 2.4 because Bundler 2.4 requires Ruby >= 2.6 but we use Ruby 2.3.8
+bundler_version="~>1.16" # must be < 2.0 because Rails 4.0.13 requires Bundler < 2.0
 
 bundle version 2>/dev/null || {
   # check if directory where gems are installed is writable

--- a/script/install/bundler.bash
+++ b/script/install/bundler.bash
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
+bundler_version="<2.4" # must be < 2.4 because Bundler 2.4 requires Ruby >= 2.6 but we use Ruby 2.3.8
+
 bundle version 2>/dev/null || {
   # check if directory where gems are installed is writable
   if [ -w "$(gem environment gemdir)" ]; then
     # don't need sudo (probably user installation e.g. rvm/rbenv, or we could be running as root)
-    cmd="gem install bundler"
+    cmd="gem install bundler -v $bundler_version"
     echo "$ $cmd"
     $cmd || exit 1
   else
     # need to use sudo to install gems (system-wide installation)
-    cmd="sudo gem install bundler"
+    cmd="sudo gem install bundler -v $bundler_version"
     echo "$ $cmd"
     $cmd || exit 1
   fi


### PR DESCRIPTION
From the commit message:

> The recently-released Bundler 2.4 requires Ruby >= 2.6, but we use Ruby 2.3.8 so `gem install bundler` fails with
> 
> ```
> ERROR:  Error installing bundler:
>         bundler requires Ruby version >= 2.6.0.
> ```
> 
> Note that this is relevant when using rbenv, but not when using rvm because it includes Bundler by default:
> https://github.com/rvm/rvm/blame/9d55c729d536dab23982946a5b65d10d0301ff78/docs/upgrade-notes.md#L29

*EDIT: Originally this PR just required Bundler < 2.4, but later we changed it to require < 2.0. See commit c2462884c9c98e98fd355f69eb8ac994e537a886 for details.*

There is a subtle footgun with the version variable that I introduced: if it contains spaces (e.g. `"< 2.4"`) then the version constraint will be split into multiple command line arguments and the command will get messed up. This is due to the way the script saves the command in a variable (`cmd`) in order to echo it then execute it (without typing it twice). I suppose this could be fixed by using an array to represent the command, but I didn't bother (I also didn't bother to put a warning in the script). I'm open to feedback though.