### PR TITLE
Fix FactoryBot deprecation warning: "Static attributes will be removed"

### DIFF
--- a/spec/factories/ai_contest_games.rb
+++ b/spec/factories/ai_contest_games.rb
@@ -2,11 +2,11 @@
 
 FactoryBot.define do
   factory :ai_contest_games do
-    ai_contest_id 1
-    ai_submission_2_id 1
-    ai_submission_1_id 1
-    record "MyText"
-    score_1 1
-    score_2 1
+    ai_contest_id { 1 }
+    ai_submission_2_id { 1 }
+    ai_submission_1_id { 1 }
+    record { "MyText" }
+    score_1 { 1 }
+    score_2 { 1 }
   end
 end

--- a/spec/factories/ai_contests.rb
+++ b/spec/factories/ai_contests.rb
@@ -2,13 +2,13 @@
 
 FactoryBot.define do
   factory :ai_contest do
-    name "MyString"
-    start_time "2013-01-07 14:51:43"
-    end_time "2013-01-07 14:51:43"
-    owner_id ""
-    finalized_at "2013-01-07 14:51:43"
-    sample_ai "MyText"
-    statement "MyText"
-    judge "MyString"
+    name { "MyString" }
+    start_time { "2013-01-07 14:51:43" }
+    end_time { "2013-01-07 14:51:43" }
+    owner_id { "" }
+    finalized_at { "2013-01-07 14:51:43" }
+    sample_ai { "MyText" }
+    statement { "MyText" }
+    judge { "MyString" }
   end
 end

--- a/spec/factories/ai_submissions.rb
+++ b/spec/factories/ai_submissions.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :ai_submission do
-    source "MyText"
-    language "MyString"
-    user_id 1
-    ai_contest_id 1
+    source { "MyText" }
+    language { "MyString" }
+    user_id { 1 }
+    ai_contest_id { 1 }
   end
 end

--- a/spec/factories/contest_relations.rb
+++ b/spec/factories/contest_relations.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :contest_relation do
-    user_id 0
-    contest_id 0
+    user_id { 0 }
+    contest_id { 0 }
     started_at { |rel| rel.contest.try(:start_time) || "2012-01-01 12:00:00" }
   end
 end

--- a/spec/factories/contest_scores.rb
+++ b/spec/factories/contest_scores.rb
@@ -2,12 +2,12 @@
 
 FactoryBot.define do
   factory :contest_score do
-    user_id 0
-    contest_relation_id 0
-    problem_id 0
-    score 0
-    attempts 0
-    attempt 0
-    submission_id 0
+    user_id { 0 }
+    contest_relation_id { 0 }
+    problem_id { 0 }
+    score { 0 }
+    attempts { 0 }
+    attempt { 0 }
+    submission_id { 0 }
   end
 end

--- a/spec/factories/contest_supervisors.rb
+++ b/spec/factories/contest_supervisors.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :contest_supervisor, :class => 'ContestSupervisors' do
-    contest_id 1
-    user_id 1
-    site_type "MyString"
-    site_id 1
+    contest_id { 1 }
+    user_id { 1 }
+    site_type { "MyString" }
+    site_id { 1 }
   end
 end

--- a/spec/factories/contests.rb
+++ b/spec/factories/contests.rb
@@ -3,11 +3,11 @@
 FactoryBot.define do
   factory :contest do
     sequence(:name) {|n| "Contest #{n}" }
-    start_time "2012-01-01 08:00:00"
-    end_time "2012-01-01 18:00:00"
-    finalized_at nil
-    duration 5.0
-    problem_set_id 0
-    owner_id 0
+    start_time { "2012-01-01 08:00:00" }
+    end_time { "2012-01-01 18:00:00" }
+    finalized_at { nil }
+    duration { 5.0 }
+    problem_set_id { 0 }
+    owner_id { 0 }
   end
 end

--- a/spec/factories/evaluators.rb
+++ b/spec/factories/evaluators.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :evaluator do
     sequence(:name) {|n| "Evaluator #{n}" }
-    description "Evaluator description"
-    source "Shell source code"
-    owner_id 0
+    description { "Evaluator description" }
+    source { "Shell source code" }
+    owner_id { 0 }
   end
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :group do
     sequence(:name) {|n| "Group #{n}" }
-    owner_id 0
+    owner_id { 0 }
   end
 end

--- a/spec/factories/languages.rb
+++ b/spec/factories/languages.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :language do
-    name "MyString"
-    compiler "MyString"
-    is_interpreted false
+    name { "MyString" }
+    compiler { "MyString" }
+    is_interpreted { false }
   end
 end

--- a/spec/factories/problem_sets.rb
+++ b/spec/factories/problem_sets.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :problem_set do
     sequence(:name) {|n| "Problem Set #{n}" }
-    owner_id 0
+    owner_id { 0 }
   end
 end

--- a/spec/factories/problems.rb
+++ b/spec/factories/problems.rb
@@ -3,19 +3,19 @@
 FactoryBot.define do
   factory :problem do
     sequence(:name) {|n| "Problem #{n}" }
-    statement "Do nothing"
+    statement { "Do nothing" }
     sequence(:input) {|n| "#{n}.in" }
     sequence(:output) {|n| "#{n}.out"}
-    memory_limit 1
-    time_limit 1
-    owner_id 0
+    memory_limit { 1 }
+    time_limit { 1 }
+    owner_id { 0 }
     factory :adding_problem do
       sequence(:name) {|n| "Adding problem #{n}" }
-      statement "Read two integers from input and output the sum."
-      input "add.in"
-      output "add.out"
-      memory_limit 30
-      time_limit 1
+      statement { "Read two integers from input and output the sum." }
+      input { "add.in" }
+      output { "add.out" }
+      memory_limit { 30 }
+      time_limit { 1 }
       test_cases { [FactoryBot.create(:test_case, :input => "5 9", :output => "14"),
                     FactoryBot.create(:test_case, :input => "100 -50", :output => "50"),
                     FactoryBot.create(:test_case, :input => "1235 942", :output => "2177"),
@@ -29,8 +29,8 @@ FactoryBot.define do
       end
 
       factory :adding_problem_stdio do
-        input nil
-        output nil
+        input { nil }
+        output { nil }
       end
     end
   end

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :setting do
     sequence(:key) {|n| "Setting #{n}" }
-    value "value"
+    value { "value" }
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -2,17 +2,17 @@
 
 FactoryBot.define do
   factory :submission do
-    source "sauce"
+    source { "sauce" }
     language { LanguageGroup.find_by_identifier("c++").current_language }
-    score nil
-    judge_log nil
-    user_id 0
-    problem_id 0
+    score { nil }
+    judge_log { nil }
+    user_id { 0 }
+    problem_id { 0 }
     created_at { Time.now }
     updated_at { created_at }
     factory :adding_submission do
       language { LanguageGroup.find_by_identifier("c++").current_language }
-      source <<sourcecode
+      source { <<sourcecode }
         #include <cstdio>
         using namespace std;
         int main() {
@@ -28,7 +28,7 @@ sourcecode
     end
     factory :adding_submission_stdio do
       language { LanguageGroup.find_by_identifier("c++").current_language }
-      source <<sourcecode
+      source { <<sourcecode }
         #include <cstdio>
         using namespace std;
         int main() {
@@ -42,7 +42,7 @@ sourcecode
     end
     factory :adding_char_submission do
       language { LanguageGroup.find_by_identifier("c++").current_language }
-      source <<sourcecode
+      source { <<sourcecode }
         #include <cstdio>
         using namespace std;
         int main() {
@@ -58,7 +58,7 @@ sourcecode
     end
     factory :adding_unsigned_submission do
       language { LanguageGroup.find_by_identifier("c++").current_language }
-      source <<sourcecode
+      source { <<sourcecode }
         #include <cstdio>
         using namespace std;
         int main() {

--- a/spec/factories/test_cases.rb
+++ b/spec/factories/test_cases.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :test_case do
     sequence(:name) {|n| "Test Case #{n}" }
-    input "Input"
-    output "Output"
+    input { "Input" }
+    output { "Output" }
   end
 end

--- a/spec/factories/test_sets.rb
+++ b/spec/factories/test_sets.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :test_set do
     sequence(:name) {|n| "Test Set #{n}" }
-    points 1
-    problem_id 0
+    points { 1 }
+    problem_id { 0 }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,12 +2,12 @@
 
 FactoryBot.define do
   factory :user, :aliases => [:owner] do
-    name "Name of User"
+    name { "Name of User" }
     sequence(:username) {|n| "user#{n}" }
     email { "#{username}@test.emails.com" }
-    password "default password"
-    confirmed_at "2012-08-05 07:00:38.285779"
-    confirmation_sent_at "2012-08-05 07:00:15.772942"
+    password { "default password" }
+    confirmed_at { "2012-08-05 07:00:38.285779" }
+    confirmation_sent_at { "2012-08-05 07:00:15.772942" }
 
     factory :admin do
       roles { [Role.find_by_name("admin")] }


### PR DESCRIPTION
See https://thoughtbot.com/blog/deprecating-static-attributes-in-factory_bot-4-11.

Warning message:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

ai_contest_id { 1 }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```

Fixed using the suggested command (needed to temporarily switch to Ruby 2.6 to install the rubocop-rspec gem).

Merge after #148.
