### PR TITLE
Refactor to remove the UserPresenter service object

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -23,8 +23,6 @@ class UserController < ApplicationController
     authorize @user, :show?
     @solved_problems = @user.user_problem_relations.where(ranked_score: 100).joins(:problem).select([:problem_id, :ranked_submission_id, {problem: :name}]).order("problems.name")
 
-    @user_presenter = UserPresenter.new(@user).permit!(*visible_attributes)
-
     respond_to do |format|
       format.html
       format.xml {render :xml => @user }

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,5 @@
+module UserHelper
+  def avatar(user)
+    image_tag user.avatar_url
+  end
+end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,9 +1,0 @@
-class UserPresenter < ApplicationPresenter
-  presents :user
-  delegate :username, :name, :email, to: :user
-
-  def avatar
-    h.tag :img, :src => user.avatar_url
-  end
-
-end

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -1,17 +1,20 @@
-<% content_for :title, @user_presenter.username %>
+<% content_for :title, @user.username %>
 <% toolbox_push :edit, edit_user_path(@user) if policy(@user).update? %>
 <% toolbox_push :edit, accounts_settings_edit_path if !policy(@user).update? && @user == current_user %>
 <% toolbox_push :back, :back %>
 
-<div style="float: left; height: 150px;"><%= @user_presenter.avatar %></div>
+<div style="float: left; height: 150px;"><%= avatar(@user) %></div>
 
 <div style="height: 150px; padding: 25px; padding-left: 200px;">
-  <% fields = { :username => "Username", :name => "Real Name", :email => "E-mail"} %>
-  <% @user_presenter.presents *fields.keys do |key, value| %>
-    <b><%= fields[key] %>:</b> <%= value %><br>
+  <b>Username:</b> <%= @user.username %><br>
+
+  <% if policy(@user).inspect? %>
+    <b>Real name:</b> <%= @user.name %><br>
+    <b>Email:</b> <%= @user.email %><br>
   <% end %>
 
   <b>Brownie Points:</b><%= @user.brownie_points %><br>
+
   <% if policy(@user).inspect? %>
     <b>School: </b><%= link_to @user.school.name, @user.school if @user.school %><br>
     <b>School Graduation Date: </b><%= @user.school_graduation %><br>

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -9,11 +9,11 @@
   <b>Username:</b> <%= @user.username %><br>
 
   <% if policy(@user).inspect? %>
-    <b>Real name:</b> <%= @user.name %><br>
+    <b>Real Name:</b> <%= @user.name %><br>
     <b>Email:</b> <%= @user.email %><br>
   <% end %>
 
-  <b>Brownie Points:</b><%= @user.brownie_points %><br>
+  <b>Brownie Points:</b> <%= @user.brownie_points %><br>
 
   <% if policy(@user).inspect? %>
     <b>School: </b><%= link_to @user.school.name, @user.school if @user.school %><br>

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-
-describe UserPresenter do
-  it "delegates username" do
-    presenter = UserPresenter.new(users(:user))
-    expect(presenter.username).to eq(users(:user).username)
-  end
-end


### PR DESCRIPTION
This is a pretty thin wrapper around the User, providing only some helpers for permissions. We *probably* have to write out the strong presenters library due to rails upgrade / ruby upgrade reasons, so this is a good place to start.