### PR TITLE
Fix line number issue when displaying submission source etc.

### DIFF
--- a/app/assets/stylesheets/code.css
+++ b/app/assets/stylesheets/code.css
@@ -26,7 +26,7 @@ pre > span:nth-child(even) {
   background-color: rgba(255,255,255,0.03);
 }
 
-pre > span::before {
+pre > span[id^="line-"]::before {
   content: counter(line-numbering);
   counter-increment: line-numbering;
   font-size: .75em;


### PR DESCRIPTION
The recent upgrade to pygments.rb 1.1.2 (#164) caused a small issue with the line numbers on syntax-highlighted code blocks (including test case inputs and outputs). It caused the numbers "1" and "2" to both appear next to the first line on top of each other:

![submission-screenshot](https://user-images.githubusercontent.com/5887562/218344870-192da3b7-ea94-44c2-9023-b2425f78ae46.png)

This happened because of a change in Pygments that intentionally inserted an empty <span> element at the beginning to preserve leading empty lines.[\[1\]][1][\[2\]][2] (See https://github.com/NZOI/nztrain/pull/164#issuecomment-1427154232 an example of the HTML.)

The line numbers are added by our CSS, and the old selector treated this dummy span as a line.

The spans that correspond to actual lines have an ID attribute of the form "line-1", "line-2" etc. So this commit fixes the issue by changing the selector to only match spans with an ID attribute starting with "line-".

~~(Ironically, there appears to be another bug in Pygments because empty lines are still not preserved; I've reproduced this using their online demo[\[3\]][3].)~~

[1]: https://www.github.com/pygments/pygments/issues/818
[2]: https://www.github.com/pygments/pygments/issues/961
[3]: https://pygments.org/demo/