### PR TITLE
Add an `after_filter` to assert that XML is forbidden

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
   before_filter :read_settings
   before_filter :check_su_loss
   before_filter :configure_permitted_parameters, if: :devise_controller?
+  after_filter :check_response_content_type
   protect_from_forgery
 
   #helper ApplicationHelper
@@ -49,6 +50,16 @@ class ApplicationController < ActionController::Base
       raise Pundit::NotAuthorizedError
     else
       super
+    end
+  end
+
+  def check_response_content_type
+    # the #content_type= check above to forbid XML runs fairly early (which is good) but it is slightly fragile
+    # (e.g. it is bypassed if <code>response.content_type=</code> is called directly)
+    # so we also verify the content type of the response after the action completes
+    # example content types that we'd like to match: "application/xml", "application/xml; charset=utf-8", "text/xml"
+    if !response.content_type.nil? && response.content_type.include?("/xml") && !current_user&.is_admin?
+      raise "Assertion failure: content type of response was #{response.content_type.inspect} but XML should be forbidden for non-admins"
     end
   end
 


### PR DESCRIPTION
Commit message:
 
> The `content_type=` check implemented in #169 runs fairly early (which is good) but it is slightly fragile (e.g. it is bypassed if `response.content_type=` is called directly).
> 
> Add an `after_filter` that raises an error if XML slipped through.

I'm not sure what's the idiomatic behaviour for such assertion failures, so I just used `raise "..."` (which [raises a RuntimeError](https://ruby-doc.org/3.2.1/Kernel.html#method-i-raise)).