### PR TITLE
Allow redis config to use ERB variables

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,6 +1,6 @@
 require 'redis'
 
-config = YAML.load( File.open( Rails.root.join("config/redis.yml") ) ).symbolize_keys
+config = YAML.load(ERB.new(File.read(Rails.root.join("config/redis.yml"))).result).symbolize_keys
 REDIS_CONFIG = config[:default].symbolize_keys
 if config[Rails.env.to_sym]
   REDIS_CONFIG.merge!(config[Rails.env.to_sym].symbolize_keys)


### PR DESCRIPTION
Makes dockerisation much easier as we can embed a version of this file in the image that is looking for specific env vars. More recent rails versions ditch the .yml.template concept for just providing more easily customisable .yml's by default. This will move us towards doing this, also.