### PR TITLE
Avoid a local jump error caused by trying to return from a block

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
 
   before_save do
     self.can_change_username = false if self.username_changed? # can only change username once
-    return true
+    true # this line should be removed once we upgrade to Rails >= 5.1, see https://guides.rubyonrails.org/5_1_release_notes.html#active-model-removals
   end
 
   has_many :problems


### PR DESCRIPTION
Returning from a block isn't really supported - instead you're supposed to use break / next to early return from a block. In any rate, this callback just needs to return true, which we can do via implicit return.

Rails 4.1 treats a non-local jump in a ActiveRecord::Callback as an error, so we have to fix this before.