### PR TITLE
Introduce a temporary model for older migrations

### DIFF
--- a/db/migrate/20131206074948_name_all_test_sets_and_cases.rb
+++ b/db/migrate/20131206074948_name_all_test_sets_and_cases.rb
@@ -1,12 +1,8 @@
-require 'set'
-
 class NameAllTestSetsAndCases < ActiveRecord::Migration
-  def up
-    Problem.find_each do |problem|
-      name_uniquely(problem.test_sets)
-      name_uniquely(problem.test_cases)
-    end
+  # Some contents of this migration have been removed to ensure
+  # we can always migrate cleanly.
 
+  def up
     add_index :test_sets, [:problem_id, :name], :unique => true
     add_index :test_cases, [:problem_id, :name], :unique => true
   end
@@ -14,19 +10,5 @@ class NameAllTestSetsAndCases < ActiveRecord::Migration
   def down
     remove_index :test_sets, [:problem_id, :name]
     remove_index :test_cases, [:problem_id, :name]
-  end
-
-  def name_uniquely relation
-    klass = relation.klass
-    names = relation.pluck(:name).compact.reject{|s|s.blank?}
-    names = Set[*names] - names.group_by { |e| e }.select { |k, v| v.size > 1 }.map(&:first)
-    i = 1
-    relation.select([:id, :name]).each do |obj|
-      if !names.include?(obj.name)
-        i+=1 while names.include?(i.to_s)
-        klass.update(obj.id, :name => i.to_s)
-        i+=1
-      end
-    end
   end
 end

--- a/db/migrate/20131209063832_fix_bad_markdown.rb
+++ b/db/migrate/20131209063832_fix_bad_markdown.rb
@@ -1,21 +1,7 @@
 class FixBadMarkdown < ActiveRecord::Migration
-  def fix_titles(string)
-    toplevel = 10
-    pos = 0
-    while inc = (string.slice(pos, string.length) =~ /^((#+)[^#].*)$/)
-      toplevel = [toplevel, $~[2].length].min
-      pos += inc + $~[0].length
-    end
-    toplevel = 2 if toplevel<2
-    string = string.gsub(/^#{Array.new(toplevel-2,"#").join}/,'').gsub(/^(#+)([^# ])/, '\1 \2')
-    return string
-  end
-
   def up
-    Problem.all.each do |problem|
-      problem.statement = fix_titles(problem.statement)
-      problem.save
-    end
+    # Data-only, legacy migration contents removed in order
+    # to maintain the ability to cleanly migrate
   end
 
   def down

--- a/db/migrate/20131217112526_change_test_set_and_test_case_sample_and_prerequisites.rb
+++ b/db/migrate/20131217112526_change_test_set_and_test_case_sample_and_prerequisites.rb
@@ -1,27 +1,15 @@
 class ChangeTestSetAndTestCaseSampleAndPrerequisites < ActiveRecord::Migration
+  # Some contents of this migration have been removed to ensure
+  # we can always migrate cleanly.
+
   def up
     add_column :test_sets, :prerequisite, :boolean, :default => false
     add_column :test_cases, :sample, :boolean, :default => false
-    execute 'UPDATE test_sets SET prerequisite = (visibility >= 2)'
-    execute 'UPDATE test_cases SET sample = true WHERE test_cases.id IN (SELECT test_case_relations.test_case_id FROM test_case_relations JOIN test_sets ON test_case_relations.test_set_id = test_sets.id WHERE test_sets.visibility = 1 OR test_sets.visibility = 3)'
     remove_column :test_sets, :visibility
   end
 
   def down
     add_column :test_sets, :visibility, :integer, :limit => 1, :null => false, :default => 0
-    execute 'UPDATE test_sets SET visibility = 2 WHERE prerequisite'
-    # suppose all test sets could be a sample test set
-    execute 'UPDATE test_sets SET visibility = visibility + 1 WHERE prerequisite'
-    # but test sets which have non-sample test cases cannot be samples
-    execute 'UPDATE test_sets SET visibility = visibility - 1 WHERE test_sets.id IN (SELECT test_case_relations.test_set_id FROM test_cases JOIN test_case_relations ON test_case_relations.test_case_id = test_cases.id WHERE NOT sample)'
-    # test cases which are not in a sample test set will need a new test set
-    Problem.all.find_each do |problem|
-      # samples which do not have a sample test set
-      missed_samples = problem.test_cases.where("id NOT IN (?) AND sample", TestCaseRelation.where(:test_set_id => problem.test_sets.where("visibility = 1 OR visibility = 3")).select(:test_case_id))
-      if missed_samples.any?
-        problem.test_sets << TestSet.new(:name => "sample test set", :points => 0, :visibility => 1, :test_case_ids => missed_samples.pluck(:id))
-      end
-    end
     remove_column :test_sets, :prerequisite
     remove_column :test_cases, :sample
   end


### PR DESCRIPTION
Remove data changes in older migrations.

Means you can migrate from zero -> now without any issues. Only the
"data only" aspects of the migrations were changed, preserving all
schema changes. This ensures we can migrate from start to finish
cleanly, and that our migrations aren't relying on schema or data that
won't be present in a clean database.

More generally, this is why people introduce tools like data-migrate [1]
and avoid using models in the their regular migrations, but hey.