### PR TITLE
Refactor calls to method_missing find_or_create_by_*

### DIFF
--- a/db/migrate/20120805061859_system_mailer_settings.rb
+++ b/db/migrate/20120805061859_system_mailer_settings.rb
@@ -1,7 +1,7 @@
 class SystemMailerSettings < ActiveRecord::Migration
   def up
-    Setting.find_or_create_by_key(:key => "system/mailer/username", :value => "nztrain@gmail.com")
-    Setting.find_or_create_by_key(:key => "system/mailer/password", :value => "training site")
+    Setting.find_or_create_by!(key: "system/mailer/username", value: "nztrain@gmail.com")
+    Setting.find_or_create_by!(key: "system/mailer/password", value: "training site")
   end
 
   def down


### PR DESCRIPTION
This is softly deprecated in Rails 4.0 [1] and are fully removed under Rails 4.1, so they need to be replaced before we can upgrade.

[1] https://guides.rubyonrails.org/4_0_release_notes.html#active-record-deprecations