### PR TITLE
Resurrect AI contests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :development, :test do
   gem 'byebug'
 
   gem 'ruby_parser' # for declarative_authorization
+  gem 'safe_attributes'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,8 @@ GEM
       sexp_processor (~> 4.9)
     rubyzip (1.3.0)
     rusage (0.2.0)
+    safe_attributes (1.0.10)
+      activerecord (>= 3.0.0)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -420,6 +422,7 @@ DEPENDENCIES
   ruby-duration
   ruby_parser
   rubyzip (= 1.3.0)
+  safe_attributes
   sass
   sass-rails
   simple-navigation (= 3.11.0)
@@ -441,4 +444,4 @@ RUBY VERSION
    ruby 2.3.8p459
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/assets/javascripts/ai_contests.js.coffee
+++ b/app/assets/javascripts/ai_contests.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/stylesheets/ai_contests.css.scss
+++ b/app/assets/stylesheets/ai_contests.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AIContests controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/ai_contests_controller.rb
+++ b/app/controllers/ai_contests_controller.rb
@@ -8,6 +8,7 @@ class AiContestsController < ApplicationController
 
   def index
     #@ai_contests = AiContest.accessible_by(current_ability)
+    @ai_contests = AiContest.all
 
     respond_to do |format|
       format.html # index.html.erb
@@ -18,6 +19,7 @@ class AiContestsController < ApplicationController
   # GET /ai_contests/1
   # GET /ai_contests/1.json
   def show
+    @ai_contest = AiContest.find(params[:id])
     respond_to do |format|
       format.html { render :layout => "ai_contest" }
       #format.json { render json: @ai_contest }
@@ -25,6 +27,7 @@ class AiContestsController < ApplicationController
   end
 
   def sample
+    @ai_contest = AiContest.find(params[:id])
     respond_to do |format|
       format.html { render :layout => "ai_contest" }
       #format.json { render json: @ai_contest }
@@ -34,7 +37,7 @@ class AiContestsController < ApplicationController
   def submit
     if request.post? # post request
       @ai_contest = AiContest.find(params[:id]) 
-      permitted_to! :submit, @ai_contest # make sure user can submit to this problem
+      # permitted_to! :submit, @ai_contest # make sure user can submit to this problem
       @ai_submission = AiSubmission.new(submit_params) # create submission
       respond_to do |format|
         if @ai_submission.submit
@@ -48,7 +51,7 @@ class AiContestsController < ApplicationController
       end
     else # get request
       @ai_contest = AiContest.find(params[:id])
-      permitted_to! :submit, @ai_contest
+      # permitted_to! :submit, @ai_contest
       @ai_submission = AiSubmission.new
       respond_to do |format|
         format.html { render :layout => "ai_contest" }
@@ -59,7 +62,7 @@ class AiContestsController < ApplicationController
 
   def submissions
     @ai_contest = AiContest.find(params[:id])
-    permitted_to! :submit, @ai_contest
+    # permitted_to! :submit, @ai_contest
     @ai_submissions = AiSubmission.where(:user_id => current_user.id, :ai_contest_id => @ai_contest.id)
     respond_to do |format|
       format.html { render :layout => "ai_contest" }
@@ -136,11 +139,13 @@ class AiContestsController < ApplicationController
   end
 
   def rejudge
+    @ai_contest = AiContest.find(params[:id])
     @ai_contest.rejudge
     redirect_to @ai_contest, :notice => "All contest games will be rejudged."
   end
 
   def judge
+    @ai_contest = AiContest.find(params[:id])
     @ai_contest.prod_judge
     redirect_to @ai_contest, :notice => "Judging has been prodded."
   end
@@ -149,7 +154,7 @@ class AiContestsController < ApplicationController
     def permitted_params
       @_permitted_params ||= begin
         permitted_attributes = [:name, :start_time, :end_time, :statement, :judge, :sample_ai, :iterations, :iterations_preview]
-        permitted_attributes << :owner_id if permitted_to? :transfer, @contest
+        permitted_attributes << :owner_id
         params.require(:ai_contest).permit(*permitted_attributes)
       end
     end
@@ -164,7 +169,7 @@ class AiContestsController < ApplicationController
     def submit_params # attributes allowed to be included in submissions
       @_submit_attributes ||= begin
         submit_attributes = [:language, :source_file]
-        submit_attributes << [:source] if permitted_to? :submit_source, @problem
+        submit_attributes << [:source]
         submit_attributes
       end
       params.require(:ai_submission).permit(*@_submit_attributes).merge(:user_id => current_user.id, :ai_contest_id => params[:id],

--- a/app/controllers/ai_contests_controller.rb
+++ b/app/controllers/ai_contests_controller.rb
@@ -1,0 +1,173 @@
+class AiContestsController < ApplicationController
+  # GET /ai_contests
+  # GET /ai_contests.json
+  # TODO: fix authorization
+  def new_ai_contest_from_params
+    @ai_contest = AiContest.new(:owner_id => current_user.id)
+  end
+
+  def index
+    #@ai_contests = AiContest.accessible_by(current_ability)
+
+    respond_to do |format|
+      format.html # index.html.erb
+      #format.json { render json: @ai_contests }
+    end
+  end
+
+  # GET /ai_contests/1
+  # GET /ai_contests/1.json
+  def show
+    respond_to do |format|
+      format.html { render :layout => "ai_contest" }
+      #format.json { render json: @ai_contest }
+    end
+  end
+
+  def sample
+    respond_to do |format|
+      format.html { render :layout => "ai_contest" }
+      #format.json { render json: @ai_contest }
+    end
+  end
+
+  def submit
+    if request.post? # post request
+      @ai_contest = AiContest.find(params[:id]) 
+      permitted_to! :submit, @ai_contest # make sure user can submit to this problem
+      @ai_submission = AiSubmission.new(submit_params) # create submission
+      respond_to do |format|
+        if @ai_submission.submit
+          # Rails.env == 'test' ? @submission.judge : spawn { @submission.judge } # Use background queue
+          format.html { redirect_to(@ai_contest, :notice => 'Submission was successfully created.') }
+          #format.xml  { render :xml => @submission, :status => :created, :location => @submission }
+        else
+          format.html { render :action => "show", :alert => 'Submission failed.' }
+          #format.xml  { render :xml => @submission.errors, :status => :unprocessable_entity }
+        end
+      end
+    else # get request
+      @ai_contest = AiContest.find(params[:id])
+      permitted_to! :submit, @ai_contest
+      @ai_submission = AiSubmission.new
+      respond_to do |format|
+        format.html { render :layout => "ai_contest" }
+      end
+    end
+
+  end
+
+  def submissions
+    @ai_contest = AiContest.find(params[:id])
+    permitted_to! :submit, @ai_contest
+    @ai_submissions = AiSubmission.where(:user_id => current_user.id, :ai_contest_id => @ai_contest.id)
+    respond_to do |format|
+      format.html { render :layout => "ai_contest" }
+    end
+  end
+
+  def scoreboard
+    @ai_contest = AiContest.find(params[:id])
+    @submissions = @ai_contest.submissions.active
+
+    respond_to do |format|
+      format.html { render :layout => "ai_contest" }
+      #format.json { render json: @ai_contest }
+    end
+  end
+
+  # GET /ai_contests/new
+  # GET /ai_contests/new.json
+  def new
+    @ai_contest = AiContest.new
+    @ai_contest.owner_id = current_user.id
+
+    respond_to do |format|
+      format.html # new.html.erb
+      format.json { render json: @ai_contest }
+    end
+  end
+
+  # GET /ai_contests/1/edit
+  def edit
+    @ai_contest = AiContest.find(params[:id])
+  end
+
+  # POST /ai_contests
+  # POST /ai_contests.json
+  def create
+    respond_to do |format|
+      if @ai_contest.update_attributes(permitted_params)
+        format.html { redirect_to @ai_contest, notice: 'Ai contest was successfully created.' }
+        format.json { render json: @ai_contest, status: :created, location: @ai_contest }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @ai_contest.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /ai_contests/1
+  # PATCH/PUT /ai_contests/1.json
+  def update
+    @ai_contest = AiContest.find(params[:id])
+
+    respond_to do |format|
+      if @ai_contest.update_attributes(ai_contest_params)
+        format.html { redirect_to @ai_contest, notice: 'Ai contest was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: "edit" }
+        format.json { render json: @ai_contest.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /ai_contests/1
+  # DELETE /ai_contests/1.json
+  def destroy
+    @ai_contest = AiContest.find(params[:id])
+    @ai_contest.destroy
+
+    respond_to do |format|
+      format.html { redirect_to ai_contests_url }
+      format.json { head :no_content }
+    end
+  end
+
+  def rejudge
+    @ai_contest.rejudge
+    redirect_to @ai_contest, :notice => "All contest games will be rejudged."
+  end
+
+  def judge
+    @ai_contest.prod_judge
+    redirect_to @ai_contest, :notice => "Judging has been prodded."
+  end
+  private
+
+    def permitted_params
+      @_permitted_params ||= begin
+        permitted_attributes = [:name, :start_time, :end_time, :statement, :judge, :sample_ai, :iterations, :iterations_preview]
+        permitted_attributes << :owner_id if permitted_to? :transfer, @contest
+        params.require(:ai_contest).permit(*permitted_attributes)
+      end
+    end
+
+    # Use this method to whitelist the permissible parameters. Example:
+    # params.require(:person).permit(:name, :age)
+    # Also, you can specialize this method with per-user checking of permissible attributes.
+    def ai_contest_params
+      permitted_params
+    end
+
+    def submit_params # attributes allowed to be included in submissions
+      @_submit_attributes ||= begin
+        submit_attributes = [:language, :source_file]
+        submit_attributes << [:source] if permitted_to? :submit_source, @problem
+        submit_attributes
+      end
+      params.require(:ai_submission).permit(*@_submit_attributes).merge(:user_id => current_user.id, :ai_contest_id => params[:id],
+        :name => params[:ai_submission][:source_file].original_filename.split('.')[0].humanize )
+    end
+end

--- a/app/controllers/ai_submissions_controller.rb
+++ b/app/controllers/ai_submissions_controller.rb
@@ -1,0 +1,64 @@
+class AiSubmissionsController < ApplicationController
+  #filter_resource_access
+
+  # GET /ai_contests/1
+  # GET /ai_contests/1.json
+  def show
+    @ai_contest = @ai_submission.ai_contest
+    iteration_limit = @ai_contest.end_time < DateTime.now || (permitted_to? :foresee, @ai_contest) ? @ai_contest.iterations : @ai_contest.iterations_preview
+    @ai_contest_games = AiContestGame.where{((ai_submission_1_id == my{@ai_submission.id}) | (ai_submission_2_id == my{@ai_submission.id})) & (iteration < iteration_limit)}
+    respond_to do |format|
+      format.html# { render :layout => "ai_submission" }
+      #format.json { render json: @ai_contest }
+    end
+  end
+
+  def rejudge
+    game_id = request.GET[:game_id]
+    game = AiContestGame.find(game_id)
+    game.score_1 = nil
+    game.score_2 = nil
+    game.record = nil
+    game.save
+    # Rails.env == 'test' ? game.judge : spawn { game.judge } # queue for background processing
+    redirect_to ai_submission_path(@ai_submission), :notice => "Submission will be rejudged"
+  end
+
+  def deactivate
+    @ai_submission.deactivate
+    redirect_to submissions_ai_contest_path(@ai_submission.ai_contest_id), :notice => "Submission deactivated"
+  end
+
+  def activate
+    @ai_submission.activate
+    redirect_to submissions_ai_contest_path(@ai_submission.ai_contest_id), :notice => "Submission activated"
+  end
+
+  private
+
+    def permitted_params
+      @_permitted_params ||= begin
+        permitted_attributes = [:name, :start_time, :end_time, :statement, :judge, :sample_ai, :iterations, :iterations_preview]
+        permitted_attributes << :owner_id if permitted_to? :transfer, @contest
+        params.require(:ai_contest).permit(*permitted_attributes)
+      end
+    end
+
+    # Use this method to whitelist the permissible parameters. Example:
+    # params.require(:person).permit(:name, :age)
+    # Also, you can specialize this method with per-user checking of permissible attributes.
+    def ai_contest_params
+      permitted_params
+    end
+
+    def submit_params # attributes allowed to be included in submissions
+      @_submit_attributes ||= begin
+        submit_attributes = [:language, :source_file]
+        submit_attributes << [:source] if permitted_to? :submit_source, @problem
+        submit_attributes
+      end
+      params.require(:ai_submission).permit(*@_submit_attributes).merge(:user_id => current_user.id, :ai_contest_id => params[:id],
+        :name => params[:ai_submission][:source_file].original_filename.split('.')[0].humanize )
+    end
+
+end

--- a/app/controllers/ai_submissions_controller.rb
+++ b/app/controllers/ai_submissions_controller.rb
@@ -4,8 +4,10 @@ class AiSubmissionsController < ApplicationController
   # GET /ai_contests/1
   # GET /ai_contests/1.json
   def show
+    @ai_submission = AiSubmission.find(params[:id])
     @ai_contest = @ai_submission.ai_contest
-    iteration_limit = @ai_contest.end_time < DateTime.now || (permitted_to? :foresee, @ai_contest) ? @ai_contest.iterations : @ai_contest.iterations_preview
+    #iteration_limit = @ai_contest.end_time < DateTime.now || (permitted_to? :foresee, @ai_contest) ? @ai_contest.iterations : @ai_contest.iterations_preview
+    iteration_limit = @ai_contest.iterations
     @ai_contest_games = AiContestGame.where{((ai_submission_1_id == my{@ai_submission.id}) | (ai_submission_2_id == my{@ai_submission.id})) & (iteration < iteration_limit)}
     respond_to do |format|
       format.html# { render :layout => "ai_submission" }
@@ -14,6 +16,7 @@ class AiSubmissionsController < ApplicationController
   end
 
   def rejudge
+    @ai_submission = AiSubmission.find(params[:id])
     game_id = request.GET[:game_id]
     game = AiContestGame.find(game_id)
     game.score_1 = nil
@@ -21,15 +24,18 @@ class AiSubmissionsController < ApplicationController
     game.record = nil
     game.save
     # Rails.env == 'test' ? game.judge : spawn { game.judge } # queue for background processing
+    game.judge
     redirect_to ai_submission_path(@ai_submission), :notice => "Submission will be rejudged"
   end
 
   def deactivate
+    @ai_submission = AiSubmission.find(params[:id])
     @ai_submission.deactivate
     redirect_to submissions_ai_contest_path(@ai_submission.ai_contest_id), :notice => "Submission deactivated"
   end
 
   def activate
+    @ai_submission = AiSubmission.find(params[:id])
     @ai_submission.activate
     redirect_to submissions_ai_contest_path(@ai_submission.ai_contest_id), :notice => "Submission activated"
   end
@@ -39,7 +45,7 @@ class AiSubmissionsController < ApplicationController
     def permitted_params
       @_permitted_params ||= begin
         permitted_attributes = [:name, :start_time, :end_time, :statement, :judge, :sample_ai, :iterations, :iterations_preview]
-        permitted_attributes << :owner_id if permitted_to? :transfer, @contest
+        permitted_attributes << :owner_id
         params.require(:ai_contest).permit(*permitted_attributes)
       end
     end
@@ -54,7 +60,7 @@ class AiSubmissionsController < ApplicationController
     def submit_params # attributes allowed to be included in submissions
       @_submit_attributes ||= begin
         submit_attributes = [:language, :source_file]
-        submit_attributes << [:source] if permitted_to? :submit_source, @problem
+        submit_attributes << [:source]
         submit_attributes
       end
       params.require(:ai_submission).permit(*@_submit_attributes).merge(:user_id => current_user.id, :ai_contest_id => params[:id],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   #helper ApplicationHelper
-  #helper ProblemsHelper
+  helper ProblemsHelper
   #helper Accounts::RequestsHelper
 
   def redirect(message)

--- a/app/helpers/ai_contests_helper.rb
+++ b/app/helpers/ai_contests_helper.rb
@@ -1,0 +1,2 @@
+module AiContestsHelper
+end

--- a/app/models/ai_contest.rb
+++ b/app/models/ai_contest.rb
@@ -1,0 +1,30 @@
+class AiContest < ActiveRecord::Base
+
+  belongs_to :owner, :class_name => :User
+
+  has_many :submissions, :class_name => :AiSubmission
+
+  def rejudge
+    # Use background processing
+    #spawn(:nice => 10) do
+    #  submissions.active.each do |sub|
+    #    sub.rejudge
+    #  end
+    #end
+  end
+  
+  def prod_judge
+    ##submissions.each_slice(submissions.length/4).to_a.each do |subs|
+    # Use background processing
+    #spawn(:nice => 12) do
+    #  submissions.active.each do |sub|
+    #      sub.judge
+    #  end
+    #end
+    #end
+  end
+
+  def unjudged_games
+    AiContestGame.joins(:ai_submission_1).joins(:ai_submission_2).where(:record => nil, :ai_submission_1=> {:active => true}, :ai_submission_2 => {:active => true}).where(:ai_contest_id => self.id)
+  end
+end

--- a/app/models/ai_contest.rb
+++ b/app/models/ai_contest.rb
@@ -6,21 +6,21 @@ class AiContest < ActiveRecord::Base
 
   def rejudge
     # Use background processing
-    #spawn(:nice => 10) do
-    #  submissions.active.each do |sub|
-    #    sub.rejudge
-    #  end
-    #end
+    Thread.new do
+      submissions.active.each do |sub|
+        sub.rejudge
+      end
+    end
   end
   
   def prod_judge
     ##submissions.each_slice(submissions.length/4).to_a.each do |subs|
     # Use background processing
-    #spawn(:nice => 12) do
-    #  submissions.active.each do |sub|
-    #      sub.judge
-    #  end
-    #end
+    Thread.new do
+      submissions.active.each do |sub|
+        sub.judge
+      end
+    end
     #end
   end
 

--- a/app/models/ai_contest_game.rb
+++ b/app/models/ai_contest_game.rb
@@ -1,0 +1,108 @@
+require 'timeout'
+
+class AiContestGame < ActiveRecord::Base
+  belongs_to :ai_contest
+  belongs_to :ai_submission_1, :class_name => :AiSubmission
+  belongs_to :ai_submission_2, :class_name => :AiSubmission
+  
+
+  def getSubmissionExe(box_path, submission)
+    name = "program_" + submission.id.to_s
+    source_file = name + ".c"
+    exe_file = name + ".exe"
+    source = submission.source
+    language = submission.language
+    if language != 'Python'
+      File.open(source_file, 'w') { |f| f.write(source) }
+      compiler = '/usr/bin/gcc'
+      if language == 'C++'
+        compiler = '/usr/bin/g++'
+      end
+      if language == 'Haskell'
+        source_file = name + '.hs'
+        compiler = '/usr/bin/ghc --make'
+      end
+
+      comp_sandbox_opts='-m262144 -w60 -e -i/dev/null'
+      comp_output = `#{box_path} #{comp_sandbox_opts} -- #{compiler} #{source_file} -O2 -lm -o #{exe_file} 2>&1`
+
+      if comp_output == ""
+        comp_output = "nothing"
+      end
+
+      self.judge_output += 'compiling with ' +  "#{box_path} #{comp_sandbox_opts} -- #{compiler} #{source_file} -O2 -lm -o #{exe_file}\n"
+
+      self.judge_output += "compiler output:\n" + comp_output + "\n"
+    else
+      self.judge_output += "interpreted language, not compiling\n"
+      File.open(exe_file, 'w') { |f| f.write(source) }
+    end
+
+    exe_file
+  end
+
+  def getExeString(box_path, judge_file, mem_limit, stack_limit, time_limit, exe_file, language)
+    if language == "Python"
+      exec = '/usr/bin/python ' + exe_file
+    else
+      exec = exe_file
+    end
+    exec_string = "\"#{box_path} -a2 -M#{judge_file} -m#{mem_limit} -k#{stack_limit} " +
+                 " -t#{time_limit} -w#{[time_limit*2,30].max} -r/dev/null -- #{exec}\""
+
+    exec_string
+  end
+
+  def judge
+    self.judge_output = ""
+    begin
+      Timeout.timeout(60) do
+        box_path = File.expand_path(Rails.root)+"/bin/box"
+        mem_limit = 100*1024
+        stack_limit = 4*1024
+        time_limit = 5
+
+        if RbConfig::CONFIG["host_cpu"] == "x86_64"
+          box_path += "64"
+        end
+        working_directory = '/tmp/game_' + id.to_s + '/'
+        if not File.directory? working_directory 
+          Dir.mkdir(working_directory)
+        end
+        Dir.chdir(working_directory)
+
+        judge_file = "eval.sh"
+        score_file = "scores.txt"
+        record_file = "record.txt"
+
+        contestant_1 = getSubmissionExe(box_path, ai_submission_1)
+        contestant_2 = getSubmissionExe(box_path, ai_submission_2)
+
+        File.open(judge_file, 'w') { |f| f.write(ai_contest.judge.gsub /\r\n?/, "\n") } # gsub added to normalize line endings (otherwise script might not run properly)
+
+        if !((FileTest.exist? contestant_1) and (FileTest.exist? contestant_2))
+          self.judge_output += "One of the submissions did not compile\n"
+          return
+        end
+
+        contestant_1_string = getExeString(box_path, "log1.out", mem_limit, stack_limit, time_limit, contestant_1, ai_submission_1.language)
+        contestant_2_string = getExeString(box_path, "log2.out", mem_limit, stack_limit, time_limit, contestant_2, ai_submission_2.language)
+
+        File.chmod(0700, judge_file)
+        system_string = "./#{judge_file} #{self.iteration} #{score_file} #{contestant_1_string} #{contestant_2_string} > #{record_file}"
+        system(system_string)
+        # store record in db
+        # get scores to put in db
+        self.record = IO.read(record_file)
+        self.score_1, self.score_2 = IO.read(score_file).split(" ").map{|x|x.to_i}
+
+        self.save
+
+        Dir.chdir('/')
+        FileUtils.rm_rf(working_directory)
+      end
+    rescue StandardError => e
+      self.judge_output = "Exception raised!\n" + e.message
+    end
+  end
+end

--- a/app/models/ai_submission.rb
+++ b/app/models/ai_submission.rb
@@ -1,0 +1,76 @@
+class AiSubmission < ActiveRecord::Base
+
+  belongs_to :ai_contest
+  belongs_to :user
+
+  scope :active, -> { where(:active => true) }
+
+  def submit
+    return false unless activate
+    true
+  end
+
+  def judge
+    ai_contest.submissions.active.each do |submission|
+      next if submission.id == self.id
+      (0...ai_contest.iterations).each do |iteration|
+        begin
+          game = AiContestGame.find_or_create_by_ai_contest_id_and_ai_submission_1_id_and_ai_submission_2_id_and_iteration(ai_contest.id, self.id, submission.id, iteration)
+          #game = AiContestGame.where(:ai_contest_id => ai_contest.id, :ai_submission_1_id => self.id, :ai_submission_2_id => submission.id, :iteration => iteration)
+          #if game.length==0
+          #  game = AiContestGame.create(:ai_contest => ai_contest, :ai_submission_1 => self, :ai_submission_2 => submission, :iteration => iteration)
+          #else
+          #  game = game.first
+          #end
+          if game.record == nil
+            game.judge
+            game.save
+          end
+        rescue Exception
+        end
+        begin
+          game = AiContestGame.find_or_create_by_ai_contest_id_and_ai_submission_1_id_and_ai_submission_2_id_and_iteration(ai_contest.id, submission.id, self.id, iteration)
+          #game = AiContestGame.where(:ai_contest_id => ai_contest.id, :ai_submission_1_id => submission.id, :ai_submission_2_id => self.id, :iteration => iteration)
+          #if game.length==0
+          #  game = AiContestGame.create(:ai_contest => ai_contest, :ai_submission_1 => self, :ai_submission_2 => submission, :iteration => iteration)
+          #else
+          #  game = game.first
+          #end
+          if game.record == nil
+            game.judge
+            game.save
+          end
+        rescue Exception
+        end
+      end
+    end
+  end
+
+  def source_file=(file)
+    self.source = IO.read(file.path)
+  end
+
+  def deactivate
+    self.active = false
+    save
+  end
+
+  def activate
+    self.active = true
+    return false unless save
+    if user_id != ai_contest.owner_id
+      AiSubmission.update_all({:active => false}, ["user_id = ? AND ai_contest_id = ? AND id != ?", user, ai_contest_id, id])
+    end
+    #Rails.env == 'test' ? self.judge : spawn(:nice => 10) { self.judge } # use background queue
+    true
+  end
+
+  def rejudge
+    #AiContestGame.update_all({:record => nil, :score_1 => nil, :score_2 => nil}, :ai_submission_1_id => id)
+    #AiContestGame.update_all({:record => nil, :score_1 => nil, :score_2 => nil}, :ai_submission_2_id => id)
+    AiContestGame.delete_all(:ai_submission_1_id => id)
+    AiContestGame.delete_all(:ai_submission_2_id => id)
+    
+    judge if self.active
+  end
+end

--- a/app/views/ai_contests/_form.html.erb
+++ b/app/views/ai_contests/_form.html.erb
@@ -1,0 +1,53 @@
+<%= form_for(@ai_contest) do |f| %>
+  <% if @ai_contest.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@ai_contest.errors.count, "error") %> prohibited this ai_contest from being saved:</h2>
+
+      <ul>
+      <% @ai_contest.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
+  <div class="field">
+    <%= f.label :start_time %><br />
+    <%= f.datetime_select :start_time %>
+  </div>
+  <div class="field">
+    <%= f.label :end_time %><br />
+    <%= f.datetime_select :end_time %>
+  </div>
+  <div class="field">
+    <%= f.label :owner_id %><br />
+    <%= f.text_field :owner_id %>
+  </div>
+  <div class="field">
+    <%= f.label :sample_ai %><br />
+    <%= f.text_area :sample_ai %>
+  </div>
+  <div class="field">
+    <%= f.label :statement %><br />
+    <%= f.text_area :statement %>
+  </div>
+  <div class="field">
+    <%= f.label :judge %><br />
+    <%= f.text_area :judge %>
+  </div>
+  <div class="field">
+    <%= f.label :iterations %><br />
+    <%= f.text_field :iterations %>
+  </div>
+  <div class="field">
+    <%= f.label :iterations_preview %> (visible games before contest ends)<br />
+    <%= f.text_field :iterations_preview %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/ai_contests/edit.html.erb
+++ b/app/views/ai_contests/edit.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, "Editing AI Contest" %>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @ai_contest %> |
+<%= link_to 'Back', ai_contests_path %>

--- a/app/views/ai_contests/index.html.erb
+++ b/app/views/ai_contests/index.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, "AI Contests" %>
+
+<table>
+  <tr>
+    <th>Title</th>
+    <th>Start time</th>
+    <th>End time</th>
+    <th></th>
+    <th></th>
+    <th></th>
+  </tr>
+
+<% @ai_contests.each do |ai_contest| %>
+  <tr>
+    <td><%= ai_contest.name %></td>
+    <td><%= ai_contest.start_time %></td>
+    <td><%= ai_contest.end_time %></td>
+    <td><%= link_to 'Show', ai_contest %></td>
+    <td><%= link_to 'Edit', edit_ai_contest_path(ai_contest) if permitted_to? :edit, ai_contest %></td>
+    <td><%= link_to 'Destroy', ai_contest, method: :delete, data: { confirm: 'Are you sure?' } if permitted_to? :destroy, ai_contest %></td>
+  </tr>
+<% end %>
+</table>
+
+<br />
+
+<%= link_to 'New AI Contest', new_ai_contest_path %>

--- a/app/views/ai_contests/index.html.erb
+++ b/app/views/ai_contests/index.html.erb
@@ -16,8 +16,8 @@
     <td><%= ai_contest.start_time %></td>
     <td><%= ai_contest.end_time %></td>
     <td><%= link_to 'Show', ai_contest %></td>
-    <td><%= link_to 'Edit', edit_ai_contest_path(ai_contest) if permitted_to? :edit, ai_contest %></td>
-    <td><%= link_to 'Destroy', ai_contest, method: :delete, data: { confirm: 'Are you sure?' } if permitted_to? :destroy, ai_contest %></td>
+    <td><%= link_to 'Edit', edit_ai_contest_path(ai_contest) %></td>
+    <td><%= link_to 'Destroy', ai_contest, method: :delete, data: { confirm: 'Are you sure?' } %></td>
   </tr>
 <% end %>
 </table>

--- a/app/views/ai_contests/new.html.erb
+++ b/app/views/ai_contests/new.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "New AI Contest" %>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', ai_contests_path %>

--- a/app/views/ai_contests/sample.html.erb
+++ b/app/views/ai_contests/sample.html.erb
@@ -1,0 +1,6 @@
+
+<p><b>Sample AI Source Code</b> - Download</p>
+
+<pre><%= @ai_contest.sample_ai %></pre>
+
+

--- a/app/views/ai_contests/scoreboard.html.erb
+++ b/app/views/ai_contests/scoreboard.html.erb
@@ -1,0 +1,41 @@
+<% iteration_limit = @ai_contest.end_time < DateTime.now ? @ai_contest.iterations : @ai_contest.iterations_preview %>
+<table>
+  <tr style="">
+    <th>
+    </th>
+    <% @submissions.each do |sub1| %>
+      <td height="150px">
+        <p align="center" style="vertical-align: middle; -webkit-transform: rotate(90deg); -moz-transform: rotate(90deg); -ms-transform: rotate(90deg); -o-transform: rotate(90deg); transform: rotate(90deg);">
+        <%= link_to "#{sub1.name[0...20]} (#{sub1.user.username})", sub1 %>
+        </p>
+      </td>
+    <% end %>
+    <th>Total</th>
+  </tr>
+  <% @submissions.each do |sub1| %>
+    <tr>
+      <td>
+        <%= link_to "#{sub1.name[0...40]} (#{sub1.user.username})", sub1 %>
+      </td>
+      <% total_score = 0 %>
+      <% @submissions.each do |sub2| %>
+        <td>
+          <p align="center">
+            <% scores = AiContestGame.where(:ai_contest_id => @ai_contest.id, :ai_submission_1_id => sub1.id, :ai_submission_2_id => sub2.id, :iteration => 0...iteration_limit).select(:score_1).map{|x|x.score_1}.reject{|x|x.nil?} %>
+            <% score = scores.inject(&:+) || 0 %>
+            <% num = scores.length %>
+            <% scores = AiContestGame.where(:ai_contest_id => @ai_contest.id, :ai_submission_1_id => sub2.id, :ai_submission_2_id => sub1.id, :iteration => 0...iteration_limit).select(:score_2).map{|x|x.score_2}.reject{|x|x.nil?} %>
+            <% score += scores.inject(&:+) || 0 %>
+            <% num += scores.length %>
+            <%= "#{score} (#{num})" %>
+            <% total_score += score %>
+          </p>
+        </td>
+      <% end %>
+      <td>
+        <%= total_score %>
+      </td>
+    </tr>
+  <% end %>
+</table>
+

--- a/app/views/ai_contests/show.html.erb
+++ b/app/views/ai_contests/show.html.erb
@@ -1,0 +1,6 @@
+<%= markdown_parse(@ai_contest.statement) %>
+
+<% if permitted_to? :edit, @ai_contest %>
+  <%= link_to 'Edit', edit_ai_contest_path(@ai_contest) %> |
+<% end %>
+<%= link_to 'Back', ai_contests_path %>

--- a/app/views/ai_contests/show.html.erb
+++ b/app/views/ai_contests/show.html.erb
@@ -1,6 +1,4 @@
 <%= markdown_parse(@ai_contest.statement) %>
 
-<% if permitted_to? :edit, @ai_contest %>
-  <%= link_to 'Edit', edit_ai_contest_path(@ai_contest) %> |
-<% end %>
+<%= link_to 'Edit', edit_ai_contest_path(@ai_contest) %> |
 <%= link_to 'Back', ai_contests_path %>

--- a/app/views/ai_contests/submissions.html.erb
+++ b/app/views/ai_contests/submissions.html.erb
@@ -11,7 +11,7 @@
       <td> <%= link_to sub.created_at.strftime("%b %d %Y, %H:%M"), sub %> </td>
       <td> <%= sub.name %> </td>
       <td> <%= sub.active ? 'Active' : 'Inactive' %> </td>
-      <td> <%= sub.active ? (permitted_to?(:deactivate, sub) ? (link_to 'Deactivate', deactivate_ai_submission_path(sub), :method => 'put') : "") : (link_to 'Activate', activate_ai_submission_path(sub), :method => 'put') %> </td>
+      <td> <%= sub.active ? (link_to 'Deactivate', deactivate_ai_submission_path(sub), :method => 'put') : (link_to 'Activate', activate_ai_submission_path(sub), :method => 'put') %> </td>
     </tr>
   <% end %>
 </table>

--- a/app/views/ai_contests/submissions.html.erb
+++ b/app/views/ai_contests/submissions.html.erb
@@ -1,0 +1,17 @@
+<b>Your submissions</b>
+<table class="main_table">
+  <tr>
+    <th>Date</th>
+    <th>Name</th>
+    <th></th>
+  </tr>
+
+  <% @ai_submissions.each do |sub| %>
+    <tr>
+      <td> <%= link_to sub.created_at.strftime("%b %d %Y, %H:%M"), sub %> </td>
+      <td> <%= sub.name %> </td>
+      <td> <%= sub.active ? 'Active' : 'Inactive' %> </td>
+      <td> <%= sub.active ? (permitted_to?(:deactivate, sub) ? (link_to 'Deactivate', deactivate_ai_submission_path(sub), :method => 'put') : "") : (link_to 'Activate', activate_ai_submission_path(sub), :method => 'put') %> </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/ai_contests/submit.html.erb
+++ b/app/views/ai_contests/submit.html.erb
@@ -1,0 +1,25 @@
+<%= form_for @ai_submission, :html => {:multipart => true}, :url => submit_ai_contest_path(@ai_contest) do |f| %>
+  <% if @ai_submission.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@ai_submission.errors.count, "error") %> prohibited this submission from being saved:</h2>
+      <ul>
+      <% @ai_submission.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="field">
+    Language: 
+    <%= f.select :language, ['C++', 'C', 'Haskell', 'Python']%>
+  </div>
+  <div class="field">
+    Source file: 
+    <%= f.file_field :source_file %>
+  </div>
+  <div class="actions">
+    <%= f.submit 'Submit' %>
+  </div>
+<% end %>
+
+

--- a/app/views/ai_submissions/show.html.erb
+++ b/app/views/ai_submissions/show.html.erb
@@ -1,0 +1,37 @@
+<p>AI Contest: <%= link_to @ai_submission.ai_contest.name, @ai_submission.ai_contest %></p>
+<p>Games for <%= "#{@ai_submission.name} (#{@ai_submission.user.username})" %></p>
+
+<table>
+  <tr>
+    <th>Game id</th>
+    <th>Board number</th>
+    <th></th>
+    <th>Player 1</th>
+    <th>Score</th>
+    <th></th>
+    <th>Player 2</th>
+    <th>Score</th>
+    <th></th>
+    <th></th>
+  </tr>
+  <% @ai_contest_games.each do |game| %>
+    <% next if game.ai_submission_1.nil? || (!game.ai_submission_1.active) or game.ai_submission_2.nil? || (!game.ai_submission_2.active) %>
+    <tr>
+      <td><%= game.id %></td>
+      <td><%= game.iteration %></td>
+      <td><%= "#{game.ai_submission_1.id}" %></td>
+      <td><%= "#{game.ai_submission_1.name} (#{game.ai_submission_1.user.username})" %></td>
+      <td><%= game.score_1 %></td>
+      <td><%= "#{game.ai_submission_2.id}" %></td>
+      <td><%= "#{game.ai_submission_2.name} (#{game.ai_submission_2.user.username})" %></td>
+      <td><%= game.score_2 %></td>
+      <td><%= link_to "Rejudge", rejudge_ai_submission_path(@ai_submission, :game_id => game.id), :method => 'post' if permitted_to? :rejudge, game %></td>
+      <td><form action="http://heythatsmyfish.com/" method="post"><textarea name="log" style="display: none"><%= game.record %></textarea><input type="submit" value="Playback" /></form></td>
+    </tr>
+  <% end %>
+
+</table>
+
+<% if permitted_to? :source, @ai_submission %>
+  <pre><%= @ai_submission.source %></pre>
+<% end %>

--- a/app/views/ai_submissions/show.html.erb
+++ b/app/views/ai_submissions/show.html.erb
@@ -25,13 +25,11 @@
       <td><%= "#{game.ai_submission_2.id}" %></td>
       <td><%= "#{game.ai_submission_2.name} (#{game.ai_submission_2.user.username})" %></td>
       <td><%= game.score_2 %></td>
-      <td><%= link_to "Rejudge", rejudge_ai_submission_path(@ai_submission, :game_id => game.id), :method => 'post' if permitted_to? :rejudge, game %></td>
+      <td><%= link_to "Rejudge", rejudge_ai_submission_path(@ai_submission, :game_id => game.id), :method => 'post' %></td>
       <td><form action="http://heythatsmyfish.com/" method="post"><textarea name="log" style="display: none"><%= game.record %></textarea><input type="submit" value="Playback" /></form></td>
     </tr>
   <% end %>
 
 </table>
 
-<% if permitted_to? :source, @ai_submission %>
-  <pre><%= @ai_submission.source %></pre>
-<% end %>
+<pre><%= @ai_submission.source %></pre>

--- a/app/views/layouts/ai_contest.html.erb
+++ b/app/views/layouts/ai_contest.html.erb
@@ -1,14 +1,10 @@
 <% content_for :title, @ai_contest.name %>
 <% content_for :content do %>
 <p>
-  <% if permitted_to? :rejudge, @ai_contest %>
     <%= link_to "Rejudge", rejudge_ai_contest_path(@ai_contest), :method => "post" %>
-  <% end %>
 </p>
 <p>
-  <% if permitted_to? :judge, @ai_contest %>
     <%= link_to "Judge", judge_ai_contest_path(@ai_contest), :method => "post" %> (Prods the judging to be maybe a bit faster)
-  <% end %>
 </p>
 
 <p>
@@ -27,7 +23,7 @@
     menu.dom_class = :tab_menu
     menu.item :statement, "overview", ai_contest_path(@ai_contest)
     menu.item :sample_ai, "sample AI", sample_ai_contest_path(@ai_contest)
-    menu.item :submit, "submit", submit_ai_contest_path(@ai_contest) if permitted_to? :submit, @ai_contest
+    menu.item :submit, "submit", submit_ai_contest_path(@ai_contest)
     menu.item :submissions, "submissions", submissions_ai_contest_path(@ai_contest)
     menu.item :scoreboard, "scoreboard", scoreboard_ai_contest_path(@ai_contest)
 #  end.render

--- a/app/views/layouts/ai_contest.html.erb
+++ b/app/views/layouts/ai_contest.html.erb
@@ -1,0 +1,40 @@
+<% content_for :title, @ai_contest.name %>
+<% content_for :content do %>
+<p>
+  <% if permitted_to? :rejudge, @ai_contest %>
+    <%= link_to "Rejudge", rejudge_ai_contest_path(@ai_contest), :method => "post" %>
+  <% end %>
+</p>
+<p>
+  <% if permitted_to? :judge, @ai_contest %>
+    <%= link_to "Judge", judge_ai_contest_path(@ai_contest), :method => "post" %> (Prods the judging to be maybe a bit faster)
+  <% end %>
+</p>
+
+<p>
+  <b>Start time:</b>
+  <%= @ai_contest.start_time %>
+</p>
+
+<p>
+  <b>End time:</b>
+  <%= @ai_contest.end_time %>
+</p>
+
+  <%=
+#  SimpleNavigation::ItemContainer.new do |menu|
+  render_navigation do |menu|
+    menu.dom_class = :tab_menu
+    menu.item :statement, "overview", ai_contest_path(@ai_contest)
+    menu.item :sample_ai, "sample AI", sample_ai_contest_path(@ai_contest)
+    menu.item :submit, "submit", submit_ai_contest_path(@ai_contest) if permitted_to? :submit, @ai_contest
+    menu.item :submissions, "submissions", submissions_ai_contest_path(@ai_contest)
+    menu.item :scoreboard, "scoreboard", scoreboard_ai_contest_path(@ai_contest)
+#  end.render
+  end
+  %>
+  <%= content_tag :div, :class => :tab_box do %>
+    <%= yield %>
+  <% end %>
+<% end %>
+<%= render :template => 'layouts/scaffold' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,25 +18,27 @@ NZTrain::Application.routes.draw do
     #end
   end
 
-  #resources :ai_contests do
-  #  member do
-  #    get 'sample'
-  #    get 'submit'
-  #    post 'submit'
-  #    get 'submissions'
-  #    get 'scoreboard'
-  #    post 'rejudge'
-  #    post 'judge'
-  #  end
-  #end
+  if Rails.env.development?
+    resources :ai_contests do
+     member do
+       get 'sample'
+       get 'submit'
+       post 'submit'
+       get 'submissions'
+       get 'scoreboard'
+       post 'rejudge'
+       post 'judge'
+     end
+    end
 
-  #resources :ai_submissions, :only => [:show] do
-  #  member do
-  #    put 'deactivate'
-  #    put 'activate'
-  #    post 'rejudge'
-  #  end
-  #end
+    resources :ai_submissions, :only => [:show] do
+     member do
+       put 'deactivate'
+       put 'activate'
+       post 'rejudge'
+     end
+    end
+  end
 
   #resources :test_sets
   #resources :test_cases

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,26 @@ NZTrain::Application.routes.draw do
     #end
   end
 
+  #resources :ai_contests do
+  #  member do
+  #    get 'sample'
+  #    get 'submit'
+  #    post 'submit'
+  #    get 'submissions'
+  #    get 'scoreboard'
+  #    post 'rejudge'
+  #    post 'judge'
+  #  end
+  #end
+
+  #resources :ai_submissions, :only => [:show] do
+  #  member do
+  #    put 'deactivate'
+  #    put 'activate'
+  #    post 'rejudge'
+  #  end
+  #end
+
   #resources :test_sets
   #resources :test_cases
 

--- a/db/migrate/20130107015143_create_ai_contests.rb
+++ b/db/migrate/20130107015143_create_ai_contests.rb
@@ -1,0 +1,16 @@
+class CreateAiContests < ActiveRecord::Migration
+  def change
+    create_table :ai_contests do |t|
+      t.string :title
+      t.timestamp :start_time
+      t.timestamp :end_time
+      t.integer :owner_id
+      t.timestamp :finalized_at
+      t.text :sample_ai
+      t.text :statement
+      t.string :judge
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20130107025725_create_ai_submissions.rb
+++ b/db/migrate/20130107025725_create_ai_submissions.rb
@@ -1,0 +1,12 @@
+class CreateAiSubmissions < ActiveRecord::Migration
+  def change
+    create_table :ai_submissions do |t|
+      t.text :source
+      t.string :language
+      t.integer :user_id
+      t.integer :ai_contest_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20130107032542_add_name_to_ai_submissions.rb
+++ b/db/migrate/20130107032542_add_name_to_ai_submissions.rb
@@ -1,0 +1,5 @@
+class AddNameToAiSubmissions < ActiveRecord::Migration
+  def change
+    add_column :ai_submissions, :name, :string
+  end
+end

--- a/db/migrate/20130107202123_add_active_to_ai_submissions.rb
+++ b/db/migrate/20130107202123_add_active_to_ai_submissions.rb
@@ -1,0 +1,5 @@
+class AddActiveToAiSubmissions < ActiveRecord::Migration
+  def change
+    add_column :ai_submissions, :active, :boolean, :default => false
+  end
+end

--- a/db/migrate/20130108005444_create_ai_contest_games.rb
+++ b/db/migrate/20130108005444_create_ai_contest_games.rb
@@ -1,0 +1,14 @@
+class CreateAiContestGames < ActiveRecord::Migration
+  def change
+    create_table :ai_contest_games do |t|
+      t.integer :ai_contest_id
+      t.integer :ai_submission_2_id
+      t.integer :ai_submission_1_id
+      t.text :record
+      t.integer :score_1
+      t.integer :score_2
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20130108012727_add_iteration_to_ai_contest_game.rb
+++ b/db/migrate/20130108012727_add_iteration_to_ai_contest_game.rb
@@ -1,0 +1,5 @@
+class AddIterationToAiContestGame < ActiveRecord::Migration
+  def change
+    add_column :ai_contest_games, :iteration, :integer
+  end
+end

--- a/db/migrate/20130108013617_add_iterations_to_ai_contests.rb
+++ b/db/migrate/20130108013617_add_iterations_to_ai_contests.rb
@@ -1,0 +1,6 @@
+class AddIterationsToAiContests < ActiveRecord::Migration
+  def change
+    add_column :ai_contests, :iterations, :integer
+    add_column :ai_contests, :iterations_preview, :integer
+  end
+end

--- a/db/migrate/20130111003321_change_judging_on_ai_contest_game.rb
+++ b/db/migrate/20130111003321_change_judging_on_ai_contest_game.rb
@@ -1,0 +1,11 @@
+class ChangeJudgingOnAiContestGame < ActiveRecord::Migration
+  def up
+    add_column :ai_contest_games, :judge_output, :text
+    change_column :ai_contests, :judge, :text
+  end
+
+  def down
+    remove_column :ai_contest_games, :judge_output
+    change_column :ai_contests, :judge, :string
+  end
+end

--- a/db/migrate/20130113010505_add_uniq_index_to_games.rb
+++ b/db/migrate/20130113010505_add_uniq_index_to_games.rb
@@ -1,0 +1,9 @@
+class AddUniqIndexToGames < ActiveRecord::Migration
+  def up
+    AiContestGame.delete_all
+    add_index(:ai_contest_games, [:iteration,:ai_submission_1_id,:ai_submission_2_id], :unique => true, :name => :each_game)
+  end
+  def down
+    remove_index :ai_contest_games, :column => [:iteration,:ai_submission_1_id,:ai_submission_2_id], :name => :each_game
+  end
+end

--- a/db/migrate/20131220034551_change_habtm_problem_associations.rb
+++ b/db/migrate/20131220034551_change_habtm_problem_associations.rb
@@ -71,9 +71,11 @@ class ChangeHabtmProblemAssociations < ActiveRecord::Migration
     rename_column :problem_sets, :title, :name
     rename_column :problems, :title, :name
     rename_column :contests, :title, :name
+    rename_column :ai_contests, :title, :name
   end
 
   def down
+    rename_column :ai_contests, :name, :title
     rename_column :contests, :name, :title
     rename_column :problems, :name, :title
     rename_column :problem_sets, :name, :title

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,47 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "ai_contest_games", force: true do |t|
+    t.integer  "ai_contest_id"
+    t.integer  "ai_submission_2_id"
+    t.integer  "ai_submission_1_id"
+    t.text     "record"
+    t.integer  "score_1"
+    t.integer  "score_2"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.integer  "iteration"
+    t.text     "judge_output"
+  end
+
+  add_index "ai_contest_games", ["iteration", "ai_submission_1_id", "ai_submission_2_id"], name: "each_game", unique: true, using: :btree
+
+  create_table "ai_contests", force: true do |t|
+    t.string   "name"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.integer  "owner_id"
+    t.datetime "finalized_at"
+    t.text     "sample_ai"
+    t.text     "statement"
+    t.text     "judge"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.integer  "iterations"
+    t.integer  "iterations_preview"
+  end
+
+  create_table "ai_submissions", force: true do |t|
+    t.text     "source"
+    t.string   "language"
+    t.integer  "user_id"
+    t.integer  "ai_contest_id"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.string   "name"
+    t.boolean  "active",        default: false
+  end
+
   create_table "contest_relations", force: true do |t|
     t.integer  "user_id"
     t.integer  "contest_id"

--- a/lib/file_size_validator.rb
+++ b/lib/file_size_validator.rb
@@ -36,7 +36,7 @@ class FileSizeValidator < ActiveModel::EachValidator
   end
 
   def validate_each(record, attribute, value)
-    raise(ArgumentError, "A CarrierWave::Uploader::Base object was expected") unless value.kind_of? CarrierWave::Uploader::Base
+    # raise(ArgumentError, "A CarrierWave::Uploader::Base object was expected") unless value.kind_of? CarrierWave::Uploader::Base
     
     value = (options[:tokenizer] || DEFAULT_TOKENIZER).call(value) if value.kind_of?(String)
 

--- a/spec/factories/ai_contest_games.rb
+++ b/spec/factories/ai_contest_games.rb
@@ -1,0 +1,12 @@
+# Read about factories at https://github.com/thoughtbot/factory_bot
+
+FactoryBot.define do
+  factory :ai_contest_games do
+    ai_contest_id { 1 }
+    ai_submission_2_id { 1 }
+    ai_submission_1_id { 1 }
+    record { "MyText" }
+    score_1 { 1 }
+    score_2 { 1 }
+  end
+end

--- a/spec/factories/ai_contests.rb
+++ b/spec/factories/ai_contests.rb
@@ -1,0 +1,14 @@
+# Read about factories at https://github.com/thoughtbot/factory_bot
+
+FactoryBot.define do
+  factory :ai_contest do
+    name { "MyString" }
+    start_time { "2013-01-07 14:51:43" }
+    end_time { "2013-01-07 14:51:43" }
+    owner_id { "" }
+    finalized_at { "2013-01-07 14:51:43" }
+    sample_ai { "MyText" }
+    statement { "MyText" }
+    judge { "MyString" }
+  end
+end

--- a/spec/factories/ai_submissions.rb
+++ b/spec/factories/ai_submissions.rb
@@ -1,0 +1,10 @@
+# Read about factories at https://github.com/thoughtbot/factory_bot
+
+FactoryBot.define do
+  factory :ai_submission do
+    source { "MyText" }
+    language { "MyString" }
+    user_id { 1 }
+    ai_contest_id { 1 }
+  end
+end

--- a/spec/helpers/ai_contests_helper_spec.rb
+++ b/spec/helpers/ai_contests_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AiContestsHelper. For example:
+#
+# describe AiContestsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       helper.concat_strings("this","that").should == "this that"
+#     end
+#   end
+# end
+describe AiContestsHelper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ai_contest_spec.rb
+++ b/spec/models/ai_contest_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe AiContest do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ai_submission_spec.rb
+++ b/spec/models/ai_submission_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe AiSubmission do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/routing/ai_contests_routing_spec.rb
+++ b/spec/routing/ai_contests_routing_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe AiContestsController do
+  before { pending }
+  describe "routing" do
+
+    it "routes to #index" do
+      expect(get("/ai_contests")).to route_to("ai_contests#index")
+    end
+
+    it "routes to #new" do
+      expect(get("/ai_contests/new")).to route_to("ai_contests#new")
+    end
+
+    it "routes to #show" do
+      expect(get("/ai_contests/1")).to route_to("ai_contests#show", :id => "1")
+    end
+
+    it "routes to #edit" do
+      expect(get("/ai_contests/1/edit")).to route_to("ai_contests#edit", :id => "1")
+    end
+
+    it "routes to #create" do
+      expect(post("/ai_contests")).to route_to("ai_contests#create")
+    end
+
+    it "routes to #update" do
+      expect(put("/ai_contests/1")).to route_to("ai_contests#update", :id => "1")
+    end
+
+    it "routes to #destroy" do
+      expect(delete("/ai_contests/1")).to route_to("ai_contests#destroy", :id => "1")
+    end
+
+  end
+end


### PR DESCRIPTION
This still needs further work before it is properly usable, including but not limited to:

 - Migrating authorization code to use Pundit policies (see 2da020e)
 - Renaming the `ai_contest_games.record` column, otherwise it throws ActiveRecord::DangerousAttributeError record_changed? is defined by Active Record
 - Changing judging to be sandboxed using isolate, and it should probably also be using a job queue