### PR TITLE
Don't indent output in install scripts

### DIFF
--- a/script/install/assets.bash
+++ b/script/install/assets.bash
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -o pipefail # to detect failure in 'bundle ... | sed ...' (see 'man bash')
 
 echo '$ rake assets:precompile'
-bundle exec rake assets:precompile | sed -e 's/^/   /g;' | cat || exit 1 # sed to indent output
+bundle exec rake assets:precompile || exit 1
 

--- a/script/install/bundle.bash
+++ b/script/install/bundle.bash
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -o pipefail # to detect failure in 'bundle ... | sed ...' (see 'man bash')
 
 lastupdate=`cat script/update.time` # get time of last update
 
@@ -8,7 +7,6 @@ if [[ "$lastupdate" < "$lastmodified" ]] ; then
   # don't use sudo with bundler, it will ask for password if necessary
   # see https://bundler.io/man/bundle-install.1.html#SUDO-USAGE
   echo "$ bundle install"
-  bundle install | sed -e 's/^/   /g;/Using/{:a;N;$!ba;s/Using [0-9a-z_ -]\+\(([0-9.]\+) \)\?\n//g}' | cat || exit 1
-  # sed indents, remove output of un-upgraded gems
+  bundle install || exit 1
 fi
 

--- a/script/install/migrate.bash
+++ b/script/install/migrate.bash
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-set -o pipefail # to detect failure in 'bundle ... | sed ...' (see 'man bash')
 
 lastupdate=`cat script/update.time` # get time of last update
 
 lastmodified=`find db/migrate/ -printf '%T+\n' | sort -r | head -n1`
 if [[ "$lastupdate" < "$lastmodified" ]] ; then
   echo '$ rake db:migrate'
-  bundle exec rake db:migrate | sed -e 's/^/   /g;' | cat || exit 1 # sed to indent output
+  bundle exec rake db:migrate || exit 1
 fi
 
 lastmodified=`find db/seeds.rb -printf '%T+\n' | sort -r | head -n1`
 if [[ "$lastupdate" < "$lastmodified" ]] ; then
   echo '$ rake db:seed'
-  bundle exec rake db:seed | sed -e 's/^/   /g;' | cat || exit 1 # sed to indent output
+  bundle exec rake db:seed || exit 1
 fi

--- a/script/install/pull.bash
+++ b/script/install/pull.bash
@@ -3,5 +3,5 @@
 # option to set another source(origin) and branch(master)
 
 echo '$ git pull'
-git pull | sed -e 's/^/   /g;' | cat
+git pull
 


### PR DESCRIPTION
Indenting the output of verbose commands such as `rake db:migrate` is nice because it visually separates their output from everything else, but there are a couple of problems with the current approach:

1. It only indents stdout, so messages written to stderr are de-synchronized and can appear out of order, which is confusing. [Can be fixed by also indenting stderr: `... |& sed ...`]

2. Some commands (e.g. `bundle install`) use colour when their output is a terminal. Piping their output suppresses this behaviour, which is a shame. [Can't be fixed easily]

3. The complex filter for `bundle install` is broken:

   - It tries to remove lines of the form "Using <gem> (<version>)", but the regex is broken (Bundler's current output format doesn't contain parentheses) so these lines are still displayed.

   - It buffers the entire output in memory, so there is no indication of progress (the output appears all at once when Bundler exits).

   - The buffering behaviour also breaks the indentation. [Easy fix]

   [All can be fixed by switching to `sed -e '/^Using/d; s/^/   /g'`]

As noted inline, these issues are easy to fix (except for colour output). But I don't think the indentation is very useful, so I'd rather just drop it altogether.

Regarding the "Using" lines in output of `bundle install`: Bundler now uses a different colour for the other lines, which helps. And I think the "Using" lines can be useful (e.g. for debugging gem versionining issues). And I'm slightly uncomfortable with the fact that the script displays `$ bundle install` but then runs a different command with modified output.