### PR TITLE
Remove custom "distinct" scope, since it's provided by Rails, and Rails 4.1 forbids that name

### DIFF
--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -43,9 +43,6 @@ class Contest < ActiveRecord::Base
     end
   end
 
-  # Scopes
-  scope :distinct, -> { select("distinct(contests.id), contests.*") }
-
   def self.user_currently_in(user_id)
     joins(:contest_relations).where(:contest_relations => { :user_id => user_id }).where("contest_relations.started_at <= :time AND contest_relations.finish_at > :time",{:time => DateTime.now})
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -25,9 +25,6 @@ class Group < ActiveRecord::Base
 
   validates :name, :presence => true, :uniqueness => { :case_sensitive => false }
 
-  # Scopes
-  scope :distinct, -> { select("distinct(groups.id), groups.*") }
-
   VISIBILITY = Enumeration.new 0 => :public, 1 => :unlisted, 2 => :private
   MEMBERSHIP = Enumeration.new 0 => [:open,'Membership is open to the public'],
                                1 => [:invitation,'Membership is by invitation or applying to join'],

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -38,7 +38,6 @@ class Problem < ActiveRecord::Base
   end
 
   # Scopes
-  scope :distinct, -> { select("distinct(problems.id), problems.*") }
 
   scope :score_by_user, ->(user_id) {
     select("problems.*, (SELECT MAX(submissions.score) FROM submissions WHERE submissions.problem_id = problems.id AND submissions.user_id = #{user_id.to_i}) AS score")

--- a/app/models/problem_set.rb
+++ b/app/models/problem_set.rb
@@ -16,9 +16,6 @@ class ProblemSet < ActiveRecord::Base
 
   validates :name, :presence => true
 
-  # Scopes
-  scope :distinct, -> { select("distinct(problem_sets.id), problem_sets.*") }
-
   def problems_with_scores_by_user(user_id)
     problems.joins("LEFT OUTER JOIN user_problem_relations ON user_problem_relations.problem_id = problems.id AND user_problem_relations.user_id = #{user_id} LEFT OUTER JOIN submissions ON submissions.id = user_problem_relations.submission_id").select([:id, :name, :test_error_count, :test_warning_count, :test_status, {submissions: [:points, :maximum_points], problem_set_problems: :weighting}])
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,9 +1,5 @@
 class Role < ActiveRecord::Base
-
   has_and_belongs_to_many :users
 
   validates :name, :presence => true
-
-  scope :distinct, -> { select("distinct(roles.id), roles.*") }
-
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -86,9 +86,6 @@ class Submission < ActiveRecord::Base
     @_mycontests ||= Contest.joins(:contest_relations, :problems).where(:contest_relations => {:user_id => user_id}, :problems => {:id => self.problem_id}).where("contest_relations.started_at <= ? AND contest_relations.finish_at > ?", self.created_at, self.created_at)
   end
 
-  # scopes (lazy running SQL queries)
-  scope :distinct, -> { select("distinct(submissions.id), submissions.*") }
-
   def self.by_user(user_id)
     where("submissions.user_id IN (?)", user_id.to_s.split(','))
   end

--- a/app/models/test_case.rb
+++ b/app/models/test_case.rb
@@ -10,8 +10,6 @@ class TestCase < ActiveRecord::Base
     errors.add :output, "cannot be nil" if output.nil?
   end
 
-  scope :distinct, -> { select("distinct(test_cases.id), test_cases.*") }
-
   include RankedModel
   ranks :problem_order, with_same: :problem_id
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,6 @@ class User < ActiveRecord::Base
 
   # Scopes
 
-  scope :distinct, -> { select("distinct(users.id), users.*") }
   scope :num_solved, -> { select("users.*, (SELECT COUNT(DISTINCT problem_id) FROM user_problem_relations WHERE user_id = users.id AND ranked_score = 100) as num_solved") }
 
   def self.find_for_authentication(conditions={})


### PR DESCRIPTION
(Extracted from commit 04b1c7cf56f5d74b8c02a164f5cfac4ca79223fe of #188)

The "distinct" method is available since Rails 4.0.0 [1] (and was available as "uniq" since Rails 3.2.0 [2]), so we no longer need to define our own "distinct" scope.

And as of Rails 4.1 it is forbidden to define a scope with a conflicting name[3], so we have to remove our "distinct" scope.

[1] https://github.com/rails/rails/commit/a1bb6c8b06db83546179175b9b2dde7912c86f9b
[2] https://github.com/rails/rails/commit/562583c7667f508493ab8c5b1a4215087fafd22d
[3] https://www.github.com/rails/rails/pull/13450