### PR TITLE
Downgrade json to 1.8.6 for Rails 4.1 compatibility; add workaround for CVE-2020-10663

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '>= 2.3.8', '< 2.4' # must be < 2.4 until we upgrade to Rails >= 4.2.8 (see https://rubyonrails.org/2017/2/21/Rails-4-2-8-has-been-released)
 
 gem 'rails', '~> 4.0.0'
+gem 'json_cve_2020_10663', '~> 1.0' # required until we update json >= 2.3, which we can only do once we upgrade to Rails >= 4.2 because activesupport 4.1.* depends on json ~> 1.7 (i.e < 2.0): https://rubygems.org/gems/activesupport/versions/4.1.16
 
 gem 'devise', '~> 3.2.2'
 gem 'psych', '~> 2.0.2' # part of stdlib, need newer version for safe_load
@@ -100,6 +101,3 @@ gem 'libv8', '~> 3.3'
 gem 'therubyracer', '~> 0.11' # required for the execjs gem (dependency)
 gem 'yui-compressor'
 #end
-
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,9 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (4.0.5)
       railties (>= 3.1.0)
-    json (2.6.3)
+    json (1.8.6)
+    json_cve_2020_10663 (1.0.0)
+      json (>= 1.7.7, < 2.3)
     libv8 (3.16.14.19)
     loofah (2.3.1)
       crass (~> 1.0.2)
@@ -395,6 +397,7 @@ DEPENDENCIES
   jquery-historyjs (= 0.2.3)
   jquery-rails (~> 3.1.3)
   jquery-ui-rails (= 4.0.5)
+  json_cve_2020_10663 (~> 1.0)
   libv8 (~> 3.3)
   loofah
   mechanize


### PR DESCRIPTION
Rails' activesupport 4.1.* depends on json ~> 1.7 (i.e < 2.0) [1], so in order to upgrade to Rails 4.1 we need to downgrade json from 2.6.3 to 1.8.6 (the highest < 2.0).

But json < 2.3 has a security vulnerability, CVE-2020-10663 [2]. So we also add a dependency on the gem 'json_cve_2020_10663', which monkey-patches the json gem to protect from this vulnerability.

(Verified that the CVE is patched using the code listed on [3].)

[1] https://rubygems.org/gems/activesupport/versions/4.1.16
[2] https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/
[3] https://github.com/rails-lts/json_cve_2020_10663

Suggested-by: Jonathan Khoo <jkhoo98@gmail.com>