### PR TITLE
Fix contestants page

### DIFF
--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -89,7 +89,7 @@ class ContestsController < ApplicationController
     @contest = Contest.find(params[:id])
     authorize @contest, :contestants?
     @groups = Group.all
-    @contest_relations = @contest.contest_relations.includes(:user).order("contest_relations.school_id, users.username")
+    @contest_relations = @contest.contest_relations.includes(:user).order("contest_relations.school_id, users.username").references(:user)
 
     render layout: 'contest'
   end

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -38,7 +38,7 @@ class Contest < ActiveRecord::Base
     problems = problem_set.problems
     self.contest_relations.find_each do |relation|
       problems.each do |problem|
-        ContestScore.find_or_initialize_by_contest_relation_id_and_problem_id(relation.id, problem.id).recalculate_and_save
+        ContestScore.find_or_initialize_by(contest_relation_id: relation.id, problem_id: problem.id).recalculate_and_save
       end
     end
   end

--- a/app/models/contest_relation.rb
+++ b/app/models/contest_relation.rb
@@ -93,7 +93,7 @@ class ContestRelation < ActiveRecord::Base
 
   def recalculate_contest_scores_and_save
     contest.problem_set.problems.each do |problem|
-      ContestScore.find_or_initialize_by_contest_relation_id_and_problem_id(self.id, problem.id).recalculate_and_save
+      ContestScore.find_or_initialize_by(contest_relation_id: self.id, problem_id: problem.id).recalculate_and_save
     end
     self.reload
   end


### PR DESCRIPTION
It was using an implicit join reference, which was deprecated in Rails 4.0 and removed in Rails 4.1.

Currently throws the following error:
```
PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "users"
LINE 1: ...t_id" = $1  ORDER BY contest_relations.school_id, users.user...
                                                             ^
: SELECT "contest_relations".* FROM "contest_relations"  WHERE "contest_relations"."contest_id" = $1  ORDER BY contest_relations.school_id, users.username
```

Under Rails 4.0, it was logging this warning:
```
DEPRECATION WARNING: It looks like you are eager loading table(s) (one of: contest_relations, users) that are referenced in a string SQL snippet. For example: 

    Post.includes(:comments).where("comments.title = 'foo'")

Currently, Active Record recognizes the table in the string, and knows to JOIN the comments table to the query, rather than loading comments in a separate query. However, doing this without writing a full-blown SQL parser is inherently flawed. Since we don't want to write an SQL parser, we are removing this functionality. From now on, you must explicitly tell Active Record when you are referencing a table from a string:

    Post.includes(:comments).where("comments.title = 'foo'").references(:comments)

If you don't rely on implicit join references you can disable the feature entirely by setting `config.active_record.disable_implicit_join_references = true`. (called from block in _app_views_contests_contestants_html_erb___2774875097299588441_47270994716840 at /apps/nztrain/app/views/contests/contestants.html.erb:159)
```