### PR TITLE
Upgrade devise to 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '>= 2.3.8', '< 2.4' # must be < 2.4 until we upgrade to Rails >= 4.2.8 (see
 gem 'rails', '4.1.16'
 gem 'json_cve_2020_10663', '~> 1.0' # required until we update json >= 2.3, which we can only do once we upgrade to Rails >= 4.2 because activesupport 4.1.* depends on json ~> 1.7 (i.e < 2.0): https://rubygems.org/gems/activesupport/versions/4.1.16
 
-gem 'devise', '~> 3.2.2'
+gem 'devise', '~> 3.4.1'
 gem 'psych', '~> 2.0.2' # part of stdlib, need newer version for safe_load
 
 # change back to cookie-based store (encrypted)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,10 +97,11 @@ GEM
     crass (1.0.5)
     daemons (1.3.1)
     debug_inspector (0.0.3)
-    devise (3.2.4)
+    devise (3.4.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
+      responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
@@ -254,6 +255,8 @@ GEM
     render_anywhere (0.0.12)
       rails (>= 3.0.7)
     request_store (1.0.8)
+    responders (1.1.2)
+      railties (>= 3.2, < 4.2)
     rmagick (5.1.0)
       pkg-config (~> 1.4)
     rqrcode (0.10.1)
@@ -393,7 +396,7 @@ DEPENDENCIES
   countries
   country_select
   coveralls
-  devise (~> 3.2.2)
+  devise (~> 3.4.1)
   facebox-rails
   factory_bot_rails
   foreman


### PR DESCRIPTION
Devise 3.4.0 added support for Rails 4.2 so it's in the critical path for that set of upgrades. 3.4.1 fixed an issue with 3.4.0, so seems worth the the patch bump.

https://github.com/heartcombo/devise/blob/3-stable/CHANGELOG.md#341---2014-10-29