### PR TITLE
Switch Devise to use secret_key_base

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,17 +4,7 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-
-  config.secret_key = '<%= SecureRandom.hex(64) %>'
-  if ActiveRecord::Base.connection.table_exists?(Setting.table_name)
-    key = nil
-    if Setting.exists?(:key => "sessions/secret_key")
-      key = Setting.find_by_key("sessions/secret_key").value
-    elsif Setting.exists?(:key => "sessions/secret_token")
-      key = Setting.find_by_key("sessions/secret_token").value
-    end
-    config.secret_key = key if key && !(key.empty?)
-  end
+  # config.secret_key = ...
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -81,7 +71,7 @@ Devise.setup do |config|
   config.stretches = 10
 
   # Setup a pepper to generate the encrypted password.
-  # config.pepper = "5bb1ea226f9eda33900717b3f16bd7752e576a32d8d7f37a7bb8e653cd54008825bc817f11b7884cf4bb8f54890bba5facdc9cc906dc4b2bc2f9e9d8a6570d4f"
+  # config.pepper = ...
 
  # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without


### PR DESCRIPTION
From the commit message:

> Devise requires a secret key to generate random tokens.
> 
> Previously, our code set this to a hard-coded value by default, or to the value of a database setting (which must be created manually).
> 
> Devise 3.2.3 added support for using Rail's secret_key_base as the secret key[1]. This commit switches to that, since it's simpler and better than the previous behaviour.
> 
> Note that deploying this commit will invalidate all existing confirmation, reset password and unlock links.
> 
> (It appears that Devise's secret key is merely used to hash tokens before storing them in the database, presumably so that even someone with read access to the database wouldn't be able to get the real tokens. So it's not really important.)
> 
> This commit also removes an unrelated commented-out generated random value for config.pepper. A cryptographic pepper is supposed to be secret, so the value shouldn't be in the source code.
> 
> [1]\: https://github.com/heartcombo/devise/blob/v3.2.3/CHANGELOG.md#323

Merge after #195, and preferably also after #193 (since the current dependency on devise is `~> 3.2.2`, which is technically not new enough, even though the locked version is 3.2.4).