### PR TITLE
Remove (commented out) google analytics code

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,18 +8,6 @@
       <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Ubuntu:400italic,Ubuntu:400"%>
       <noscript><style type="text/css">.js_only { display: none; }</style></noscript>
       <%= csrf_meta_tag %>
-      <!-- Google Analytics -->
-      <!--<script defer="defer" async type="text/javascript">
-        var _gaq = _gaq || [];
-        _gaq.push(['_setAccount', 'UA-37616650-1'],['_setDomainName', 'none'],['_trackPageview']);
-
-        (function() {
-          var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-          ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-        })();
-      </script>-->
-
       <title><%= yield :title %><%= "#{((yield :title).length>0?" - ":"")}NZOI Training" %></title>
       <%= yield :head %>
   </head>


### PR DESCRIPTION
It's referencing a GA product that doesn't exist, no-one has access to that property, and it's just cruft.