### PR TITLE
Extract DevelopmentMailInterceptor setup from config/environments/

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,3 @@ NZTrain::Application.configure do
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5 # removed in rails 4
 end
-
-ActionMailer::Base.register_interceptor(DevelopmentMailInterceptor) if Rails.env.development?
-

--- a/config/initializers/mail_interceptor.rb
+++ b/config/initializers/mail_interceptor.rb
@@ -1,0 +1,4 @@
+if Rails.env.development?
+  require 'development_mail_interceptor'
+  Mail.register_interceptor(DevelopmentMailInterceptor)
+end


### PR DESCRIPTION
This makes rails upgrades easier, as it means the diff between the
template-added is near-zero. There's no reason not to set this up here,
we just have to be a little careful about rails load order (use
Mail#register_interceptor instead of ActionMailer).