### PR TITLE
Remove our String.shorten extension

### DIFF
--- a/app/views/test_cases/index.html.erb
+++ b/app/views/test_cases/index.html.erb
@@ -18,8 +18,8 @@
 
 <% @test_cases.each do |test_case| %>
   <tr>
-    <td><%= simple_format(test_case.input.shorten) %></td>
-    <td><%= simple_format(test_case.output.shorten) %></td>
+    <td><%= simple_format(test_case.input.truncate(100)) %></td>
+    <td><%= simple_format(test_case.output.truncate(100)) %></td>
     <td><%= test_case.test_set_ids.to_s %></td>
     <td><%= test_case.name %></td>
     <td><%= test_case.problem_ids %></td>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,9 +1,5 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
-require 'ext/string'
-#longest length a string can be before it's truncated in index view
-SHORTEN_LIMIT = 100
-
 #Initialize the rails application
 NZTrain::Application.initialize!

--- a/lib/ext/string.rb
+++ b/lib/ext/string.rb
@@ -1,9 +1,0 @@
-class String
-  def shorten
-    if self.size > SHORTEN_LIMIT
-      return self[0,SHORTEN_LIMIT] + "..."
-    end
-    
-    return self
-  end
-end


### PR DESCRIPTION
Rails 3 has a built-in truncate method that we can use instead.

Also remove the constant SHORTEN_LIMIT, it is only used in two places and removing it makes it easier to update the configuration.

Suggested-by: \@bagedevimo

~~Review and merge after #203 because of merge conflicts.~~ *Done*

*Edit:*

The place that uses it is actually dead code. Updating it anyway, can be deleted separately (draft: #205).