### PR TITLE
Move the time_zone configuration to the "default" line

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module NZTrain
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Auckland'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
@@ -52,7 +52,6 @@ module NZTrain
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
-    config.time_zone = "Auckland"
     config.action_mailer.default_url_options = { :host => 'train.nzoi.org.nz' }
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
Minimises the number of differences between the original file that Rails
generated and our configured version.