### PR TITLE
Remove explicit setting of config.encoding

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,9 +28,6 @@ module NZTrain
     # JavaScript files you want as :defaults (application.js is always included).
     # config.action_view.javascript_expansions[:defaults] = %w(jquery rails)
 
-    # Configure the default encoding used in templates for Ruby 1.9.
-    config.encoding = "utf-8"
-
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 


### PR DESCRIPTION
This value we are setting was made default in Rails 3, at least [1]. In
very modern ruby, I believe you can't even disable utf-8 parsing
anymore.

[1] https://github.com/rails/rails/commit/ec73710c79c5e1587b489b2ce05cc34138acf071