### PR TITLE
Remove config.include_all_helpers call

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,9 +28,6 @@ module NZTrain
     # JavaScript files you want as :defaults (application.js is always included).
     # config.action_view.javascript_expansions[:defaults] = %w(jquery rails)
 
-    # Configure the default encoding used in templates for Ruby 1.9.
-    config.encoding = "utf-8"
-
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,8 +31,6 @@ module NZTrain
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
-    config.action_controller.include_all_helpers = false
-
     # Enable the asset pipeline
     config.assets.enabled = true
     config.assets.paths << Rails.root.join("fonts")


### PR DESCRIPTION
This became the default in Rails 3.1

https://github.com/rails/rails/blob/b1d57fb8c87d771d9a74ac31cd9969e6806b03b2/guides/source/3_1_release_notes.md#action-controller