### PR TITLE
Limit /users/online to staff

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   end
 
   def online
-    authorize User.new, :index?
+    authorize User.new, :inspect?
     @users = policy_scope(User).order(:last_seen_at).reverse_order
     render
   end


### PR DESCRIPTION
The "community" nav menu only shows the "online" link to staff, however there is no corresponding authorization check to prevent non-staff from accessing that page via a direct link. This commit adds the check.

(Later on we'll add more restrictions the other "community" pages due to privacy. We are starting with the "online" page because it's not even visible in the nav menu, and because it's the only page that shows the last login time -- which is on the more sensitive side.)

See: #192

Reported-by: @thebrucecgit