### PR TITLE
Limit /users/newest to staff

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   end
 
   def newest
-    authorize User.new, :index?
+    authorize User.new, :inspect?
     @users = policy_scope(User).order(:created_at).reverse_order.limit(100)
     render
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -106,10 +106,12 @@
                 <li><a href="#" onClick="return false;">community</a>
                   <ul>
                     <li><a href="<%= main_app.users_path %>">users</a>
-                      <ul>
-                        <li><a href="<%= main_app.newest_users_path %>">newest</a></li>
-                        <% if policy(User.new).inspect? %><li><a href="<%= main_app.online_users_path %>">online</a></li><% end %>
-                      </ul>
+                      <% if policy(User.new).inspect? %>
+                        <ul>
+                          <li><a href="<%= main_app.newest_users_path %>">newest</a></li>
+                          <li><a href="<%= main_app.online_users_path %>">online</a></li>
+                        </ul>
+                      <% end %>
                     </li>
                   </ul>
                 </li>


### PR DESCRIPTION
We are restricting the "community" pages due to privacy concerns. The "newest" page shows the users sorted by their registration time, and it's the only page that shows the registration time. So in this commit we protect the registration time field by hiding the "newest" page from non-staff.

See: #192

Reported-by: @thebrucecgit