### PR TITLE
Replace therubyracer with mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,6 @@ gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier', '>=1.0.3'
 gem 'libv8', '~> 3.3'
-gem 'therubyracer', '~> 0.11' # required for the execjs gem (dependency)
+gem 'mini_racer', '~> 0.4.0'
 gem 'yui-compressor'
 #end

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ gem 'sass'
 gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier', '>=1.0.3'
-gem 'libv8', '~> 3.3'
 gem 'mini_racer', '~> 0.4.0'
 gem 'yui-compressor'
 #end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     json_cve_2020_10663 (1.0.0)
       json (>= 1.7.7, < 2.3)
     libv8 (3.16.14.19)
+    libv8-node (15.14.0.1)
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -170,6 +171,8 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     mini_portile2 (2.4.0)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minitest (5.15.0)
     money (6.10.1)
       i18n (>= 0.6.4, < 1.0)
@@ -245,7 +248,6 @@ GEM
       json
     redcarpet (3.2.3)
     redis (3.3.5)
-    ref (2.0.0)
     render_anywhere (0.0.12)
       rails (>= 3.0.7)
     request_store (1.0.8)
@@ -337,9 +339,6 @@ GEM
     superfish-rails (1.6.0.1)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -402,6 +401,7 @@ DEPENDENCIES
   libv8 (~> 3.3)
   loofah
   mechanize
+  mini_racer (~> 0.4.0)
   newrelic_rpm
   nokogiri (~> 1.10.10)
   pdf-reader
@@ -433,7 +433,6 @@ DEPENDENCIES
   squeel
   strong_presenter (~> 0.2.2)
   superfish-rails (~> 1.6.0)
-  therubyracer (~> 0.11)
   tilt
   uglifier (>= 1.0.3)
   whenever

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,6 @@ GEM
     json (1.8.6)
     json_cve_2020_10663 (1.0.0)
       json (>= 1.7.7, < 2.3)
-    libv8 (3.16.14.19)
     libv8-node (15.14.0.1)
     loofah (2.3.1)
       crass (~> 1.0.2)
@@ -398,7 +397,6 @@ DEPENDENCIES
   jquery-rails (~> 3.1.3)
   jquery-ui-rails (= 4.0.5)
   json_cve_2020_10663 (~> 1.0)
-  libv8 (~> 3.3)
   loofah
   mechanize
   mini_racer (~> 0.4.0)


### PR DESCRIPTION
therubyracer is unmaintained and difficult to use in newer contexts. mini_racer
is supposed to be a drop-in replacement, and it'll be pretty obvious it it doesn't
work for any reason as assets:precompile won't work.

[1] https://github.com/rubyjs/therubyracer
[2] https://github.com/rubyjs/mini_racer
