### PR TITLE
Update gem "pundit"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'rmagick'
 gem 'carrierwave', '1.3.2'
 gem 'will_paginate'
 gem 'has_scope'
-gem 'pundit', '0.2.1'
+gem 'pundit', '~> 1.1.0'
 gem 'recaptcha', :require => 'recaptcha/rails'
 gem 'loofah'
 gem 'whenever', :require => false # for cron jobs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
       ttfunk (~> 1.5)
     psych (2.0.17)
     public_suffix (4.0.7)
-    pundit (0.2.1)
+    pundit (1.1.0)
       activesupport (>= 3.0.0)
     pygments.rb (1.1.2)
       multi_json (>= 1.0.0)
@@ -451,7 +451,7 @@ DEPENDENCIES
   pg
   prawn
   psych (~> 2.0.2)
-  pundit (= 0.2.1)
+  pundit (~> 1.1.0)
   pygments.rb (~> 1.1.0)
   qless
   rails (~> 4.2)


### PR DESCRIPTION
The current version has a number of deprecations, and there are no
breaking changes that should affect us until this version (1.1.0).

Going to 2.0.0 is probably possible, but not useful right now.
