### PR TITLE
Restrict permissions on config/secret_key_base.*.txt

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -27,8 +27,8 @@ if NZTrain::Application.config.secret_key_base.nil?
   # Code inspired by Rails.application.generate_local_secret
   # (https://github.com/rails/rails/blob/v7.1.2/railties/lib/rails/application.rb#L665)
   filename = Rails.root.join("config/secret_key_base.#{Rails.env}.txt")
-  if !File.exist?(filename)
-    File.open(filename, "wb", 0600) { |f| f.write(SecureRandom.hex(64)) }
+  unless File.exist?(filename)
+    File.open(filename, "wb", 0o600) { |f| f.write(SecureRandom.hex(64)) }
   end
   NZTrain::Application.config.secret_key_base = File.binread(filename).strip
 end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -26,9 +26,9 @@ if NZTrain::Application.config.secret_key_base.nil?
   # Randomly generate a secret and store it in config/secret_key_base.#{env}.txt
   # Code inspired by Rails.application.generate_local_secret
   # (https://github.com/rails/rails/blob/v7.1.2/railties/lib/rails/application.rb#L665)
-  file = Rails.root.join("config/secret_key_base.#{Rails.env}.txt")
-  if !File.exist?(file)
-    File.binwrite(file, SecureRandom.hex(64))
+  filename = Rails.root.join("config/secret_key_base.#{Rails.env}.txt")
+  if !File.exist?(filename)
+    File.open(filename, "wb", 0600) { |f| f.write(SecureRandom.hex(64)) }
   end
-  NZTrain::Application.config.secret_key_base = File.binread(file).strip
+  NZTrain::Application.config.secret_key_base = File.binread(filename).strip
 end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -27,7 +27,7 @@ if NZTrain::Application.config.secret_key_base.nil?
   # Code inspired by Rails.application.generate_local_secret
   # (https://github.com/rails/rails/blob/v7.1.2/railties/lib/rails/application.rb#L665)
   filename = Rails.root.join("config/secret_key_base.#{Rails.env}.txt")
-  unless File.exist?(filename)
+  if !File.exist?(filename)
     File.open(filename, "wb", 0o600) { |f| f.write(SecureRandom.hex(64)) }
   end
   NZTrain::Application.config.secret_key_base = File.binread(filename).strip


### PR DESCRIPTION
I should have done this from the start in #195.

(Review notes: The noise is because I renamed the variable "file" to "filename", to distinguish from the File object.)

For deploying, this will have to be applied manually (using chmod).