### PR TITLE
Remove unused ruby_parser gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,6 @@ group :development, :test do
 
   gem 'byebug'
 
-  gem 'ruby_parser' # for declarative_authorization
-
   gem 'standard'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,8 +345,6 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_parser (3.10.1)
-      sexp_processor (~> 4.9)
     rubyzip (1.3.0)
     rusage (0.2.0)
     sass (3.5.5)
@@ -362,7 +360,6 @@ GEM
       tilt (>= 1.1, < 3)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
-    sexp_processor (4.10.0)
     simple-navigation (3.11.0)
       activesupport (>= 2.3.2)
     simple_form (3.2.1)
@@ -492,7 +489,6 @@ DEPENDENCIES
   rqrcode
   rspec-rails (~> 3.0)
   ruby-duration
-  ruby_parser
   rubyzip (= 1.3.0)
   sass
   sass-rails


### PR DESCRIPTION
Misc cleanup, spotted during #215 and wanted to create a PR so I won't forget. (Will probably have merge conflicts, but easy to redo.)