### PR TITLE
Fix deprecation: pass id instead of object to `.exists?`

### DIFF
--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -5,9 +5,9 @@ class Groups::MembersController < ApplicationController
   def load_group_request
     @group = Group.find(params[:id])
     @request = Request.find(params[:request_id])
-    if @group.invitations.exists?(@request) && @request.pending?
+    if @group.invitations.exists?(@request.id) && @request.pending?
       @request_type = :invitation
-    elsif @group.join_requests.exists?(@request) && @request.pending?
+    elsif @group.join_requests.exists?(@request.id) && @request.pending?
       @request_type = :join_request
     else
       redirect_to(@group, :alert => 'Invalid request operation')
@@ -27,7 +27,7 @@ class Groups::MembersController < ApplicationController
     @user = User.find_by_username(params[:username])
     if @user.nil?
       redirect_to(members_group_path(@group), :alert => "No user found with username \"#{params[:username]}\"")
-    elsif @group.members.exists?(@user)
+    elsif @group.members.exists?(@user.id)
       redirect_to(members_group_path(@group), :alert => "#{@user.username} is already a member of this group")
     else
       @group.join(@user)
@@ -63,7 +63,7 @@ class Groups::MembersController < ApplicationController
   def apply
     @group = Group.find(params[:id])
     authorize @group, :apply?
-    if @group.members.exists?(current_user)
+    if @group.members.exists?(current_user.id)
       redirect_to(@group, :alert => "You are already a member of this group")
     elsif invitation = @group.invitations.pending.where(:target_id => @user).first
       invitation.accept!
@@ -83,7 +83,7 @@ class Groups::MembersController < ApplicationController
       @user = User.find_by_username(params[:username])
       if @user.nil?
         redirect_to(invites_members_group_path(@group), :alert => "No user found with username \"#{params[:username]}\"")
-      elsif @group.members.exists?(@user)
+      elsif @group.members.exists?(@user.id)
         redirect_to(invites_members_group_path(@group), :alert => "#{@user.username} is already a member of this group")
       elsif join_request = @group.join_requests.pending.where(:subject_id => @user).first
         join_request.accept!

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -14,7 +14,7 @@ class GroupsController < ApplicationController
     authorize @group, :update?
     @contest = Contest.find(params[:contest_id])
     authorize @contest, :use?
-    if @group.contests.exists?(@contest)
+    if @group.contests.exists?(@contest.id)
       redirect_to(@contest, :alert => "This group already has access to this contest")
       return
     end

--- a/app/controllers/problem_sets_controller.rb
+++ b/app/controllers/problem_sets_controller.rb
@@ -13,7 +13,7 @@ class ProblemSetsController < ApplicationController
     authorize @problem_set, :update?
     problem = Problem.find(params[:id]) # note switched params - TODO: fix form
     authorize problem, :use?
-    if @problem_set.problems.exists?(problem)
+    if @problem_set.problems.exists?(problem.id)
       redirect_to(problem, :alert => "This problem set already contains this problem")
       return
     end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -53,7 +53,7 @@ class UserController < ApplicationController
     authorize @user, :update?
     role = Role.find(params[:user][:role_ids])
     authorize role, :grant?
-    if @user.roles.exists?(role)
+    if @user.roles.exists?(role.id)
       redirect_to(@user, :alert => "This user already has this role")
       return
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -32,7 +32,7 @@ class Group < ActiveRecord::Base
                                3 => [:private,'Membership is by private invitation']
 
   def join(current_user)
-    if self.members.exists?(current_user)
+    if self.members.exists?(current_user.id)
       false
     else
       self.members.push(current_user)

--- a/app/views/layouts/group.html.erb
+++ b/app/views/layouts/group.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, @group.name %>
 <% toolbox_push :edit, edit_group_path(@group) if policy(@group).update? %>
 <% toolbox_push :delete, @group if policy(@group).destroy? %>
-<% if @group.members.exists?(current_user) %>
+<% if @group.members.exists?(current_user.id) %>
   <% toolbox_push :leave, leave_group_path(@group) if policy(@group).leave? %>
 <% elsif policy(@group).join? %>
   <%= toolbox_push :join, join_group_path(@group)  %>

--- a/spec/features/invitation_and_join_request_spec.rb
+++ b/spec/features/invitation_and_join_request_spec.rb
@@ -15,7 +15,7 @@ feature 'invitation and join request' do
 
     @invitation = @group.invitations.pending.where(:target_id => users(:user)).first
 
-    expect(@group.members.exists?(users(:user))).to be false
+    expect(@group.members.exists?(users(:user).id)).to be false
 
     login_as users(:user), :scope => :user
     visit accounts_requests_path
@@ -26,7 +26,7 @@ feature 'invitation and join request' do
       end
     end.to change{ @group.invitations.pending.count }.by(-1)
 
-    expect(@group.members.exists?(users(:user))).to be true
+    expect(@group.members.exists?(users(:user).id)).to be true
   end
 
   scenario 'group member invites a user and cancels the invitation' do
@@ -58,7 +58,7 @@ feature 'invitation and join request' do
     apply_link = find :xpath, "//a[@href = '#{apply_group_path(@group)}']"
     expect { apply_link.click }.to change{ @group.join_requests.pending.count }.by(1)
 
-    expect(@group.members.exists?(users(:user))).to be false
+    expect(@group.members.exists?(users(:user).id)).to be false
     @join_request = @group.join_requests.pending.where(:subject_id => users(:user)).first
 
     login_as users(:organiser)
@@ -66,7 +66,7 @@ feature 'invitation and join request' do
     accept_link = find :xpath, "//a[@href = '#{accept_members_group_path(@group, @join_request)}']"
     expect{ accept_link.click }.to change{ @group.join_requests.pending.count }.by(-1)
 
-    expect(@group.members.exists?(users(:user))).to be true
+    expect(@group.members.exists?(users(:user).id)).to be true
   end
 
   scenario 'user applies to join group, and group owner rejects join request' do
@@ -84,6 +84,6 @@ feature 'invitation and join request' do
     reject_link = find :xpath, "//a[@href = '#{reject_members_group_path(@group, @join_request)}']"
     expect{ reject_link.click }.to change{ @group.join_requests.pending.count }.by(-1)
 
-    expect(@group.members.exists?(users(:user))).to be false
+    expect(@group.members.exists?(users(:user).id)).to be false
   end
 end


### PR DESCRIPTION
Fixes some deprecation warnings from Rails 4.2 update (#199).

Not fully tested (only checked that the tests pass).

From the commit message:

> Fixes the following Rails 4.2 deprecation warning:
> 
> > DEPRECATION WARNING: You are passing an instance of ActiveRecord::Base to `exists?`. Please pass the id of the object by calling `.id`.
> 
> See: https://guides.rubyonrails.org/4_2_release_notes.html#active-record-deprecations