### PR TITLE
Don't swallow errors in after_commit/after_rollback callbacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,9 @@ module NZTrain
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # Do not swallow errors in after_commit/after_rollback callbacks.
+    config.active_record.raise_in_transactional_callbacks = true
+
     # JavaScript files you want as :defaults (application.js is always included).
     # config.action_view.javascript_expansions[:defaults] = %w(jquery rails)
 


### PR DESCRIPTION
This silences the following Rails 4.2 deprecation warning by opting into the new behaviour:

> DEPRECATION WARNING: Currently, Active Record suppresses errors raised within `after_rollback`/`after_commit` callbacks and only print them to the logs. In the next version, these errors will no longer be suppressed. Instead, the errors will propagate normally just like in other Active Record callbacks.

Docs: https://guides.rubyonrails.org/v4.2.0/upgrading_ruby_on_rails.html#error-handling-in-transaction-callbacks

The old behaviour will be removed in Rails 5 [1].

[1]\: https://github.com/rails/rails/commit/07d3d402341e81ada0214f2cb2be1da69eadfe72

---

We don't appear to use after_commit / after_rollback, so nothing to test? (The specs pass.)