### PR TITLE
Use the shopify fork of qless

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,8 @@ gem 'pg'
 gem 'backup'
 
 # Redis and Background Processing
-gem 'redis', '< 4.0'
-gem 'qless'#, :github => 'ronalchn/qless', :branch => 'nztrain'
+gem 'redis'
+gem 'qless', :github => 'Shopify/qless'
 gem 'connection_pool'
 gem 'sinatra'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/Shopify/qless.git
+  revision: 568cba040bca28064762859703a82a7e574e63f6
+  specs:
+    qless (0.11.5)
+      erubi (~> 1.7)
+      metriks (~> 0.9)
+      redis (~> 4.4.0)
+      rusage (~> 0.2.0)
+      sinatra (>= 1.3, <= 2.2.3)
+      statsd-ruby (~> 1.3)
+      thin (~> 1.7)
+      thor
+      vegas (~> 0.1.11)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -98,7 +113,7 @@ GEM
       thor (~> 0.19.4)
       tins (~> 1.6)
     crass (1.0.5)
-    daemons (1.3.1)
+    daemons (1.4.1)
     debug_inspector (0.0.3)
     devise (3.4.1)
       bcrypt (~> 3.0)
@@ -123,8 +138,6 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     foreman (0.84.0)
       thor (~> 0.19.1)
@@ -188,7 +201,6 @@ GEM
     money (6.10.1)
       i18n (>= 0.6.4, < 1.0)
     multi_json (1.15.0)
-    multipart-post (2.0.0)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
@@ -223,16 +235,6 @@ GEM
       activesupport (>= 3.0.0)
     pygments.rb (1.1.2)
       multi_json (>= 1.0.0)
-    qless (0.12.0)
-      metriks (~> 0.9)
-      redis (>= 2.2, < 4.0.0.rc1)
-      rusage (~> 0.2.0)
-      sentry-raven (~> 0.15.6)
-      sinatra (>= 1.3, < 2.1)
-      statsd-ruby (~> 1.3)
-      thin (~> 1.6)
-      thor (~> 0.19.1)
-      vegas (~> 0.1.11)
     racc (1.5.2)
     rack (1.6.13)
     rack-protection (1.5.5)
@@ -273,7 +275,7 @@ GEM
     recaptcha (4.6.3)
       json
     redcarpet (3.2.3)
-    redis (3.3.5)
+    redis (4.4.0)
     render_anywhere (0.0.12)
       rails (>= 3.0.7)
     request_store (1.0.8)
@@ -333,8 +335,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sentry-raven (0.15.6)
-      faraday (>= 0.7.6)
     sexp_processor (4.10.0)
     simple-navigation (3.11.0)
       activesupport (>= 2.3.2)
@@ -369,7 +369,7 @@ GEM
     standard (0.2.5)
       rubocop (~> 0.80.1)
       rubocop-performance (~> 1.5.2)
-    statsd-ruby (1.4.0)
+    statsd-ruby (1.5.0)
     strong_attributes (0.0.2)
       activesupport (>= 3.0)
     strong_presenter (0.2.2)
@@ -381,7 +381,7 @@ GEM
     superfish-rails (1.6.0.1)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    thin (1.7.2)
+    thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
@@ -453,12 +453,12 @@ DEPENDENCIES
   psych (~> 2.0.2)
   pundit (= 0.2.1)
   pygments.rb (~> 1.1.0)
-  qless
+  qless!
   rails (~> 4.2)
   ranked-model (< 0.4.3)
   recaptcha
   redcarpet
-  redis (< 4.0)
+  redis
   render_anywhere
   responders
   rmagick


### PR DESCRIPTION
The mainstream release of qless is very unmaintained, and doesn't work with modern redis versions at all.

Shopify forked, and added a series of batches which fix a few bugs and improve a few UI quirks. Their fork is now also unmaintained, but it's more recently unmaintained, so that's nice.