### PR TITLE
Commit updated db/schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "contest_relations", force: true do |t|
+  create_table "contest_relations", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "contest_id"
     t.datetime "started_at"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "contest_relations", ["contest_id", "user_id"], name: "index_contest_relations_on_contest_id_and_user_id", unique: true, using: :btree
   add_index "contest_relations", ["user_id", "started_at"], name: "index_contest_relations_on_user_id_and_started_at", using: :btree
 
-  create_table "contest_scores", force: true do |t|
+  create_table "contest_scores", force: :cascade do |t|
     t.integer  "contest_relation_id", null: false
     t.integer  "problem_id",          null: false
     t.integer  "score"
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
 
   add_index "contest_scores", ["contest_relation_id", "problem_id"], name: "index_contest_scores_on_contest_relation_id_and_problem_id", using: :btree
 
-  create_table "contest_supervisors", force: true do |t|
+  create_table "contest_supervisors", force: :cascade do |t|
     t.integer  "contest_id"
     t.integer  "user_id"
     t.string   "site_type"
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.datetime "scheduled_start_time"
   end
 
-  create_table "contests", force: true do |t|
+  create_table "contests", force: :cascade do |t|
     t.string   "name"
     t.datetime "start_time"
     t.datetime "end_time"
@@ -80,13 +80,13 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.boolean  "only_rank_official_contestants", default: false
   end
 
-  create_table "entities", force: true do |t|
+  create_table "entities", force: :cascade do |t|
     t.string  "name"
     t.integer "entity_id"
     t.string  "entity_type"
   end
 
-  create_table "evaluators", force: true do |t|
+  create_table "evaluators", force: :cascade do |t|
     t.string   "name",                     null: false
     t.text     "description", default: "", null: false
     t.text     "source",      default: "", null: false
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.datetime "updated_at"
   end
 
-  create_table "file_attachments", force: true do |t|
+  create_table "file_attachments", force: :cascade do |t|
     t.string   "name"
     t.string   "file_attachment"
     t.integer  "owner_id"
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.datetime "updated_at",      null: false
   end
 
-  create_table "filelinks", force: true do |t|
+  create_table "filelinks", force: :cascade do |t|
     t.integer  "root_id"
     t.integer  "file_attachment_id"
     t.datetime "created_at"
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "filelinks", ["file_attachment_id"], name: "index_filelinks_on_file_attachment_id", using: :btree
   add_index "filelinks", ["root_id", "filepath"], name: "index_filelinks_on_root_id_and_filepath", using: :btree
 
-  create_table "group_contests", force: true do |t|
+  create_table "group_contests", force: :cascade do |t|
     t.integer "group_id"
     t.integer "contest_id"
   end
@@ -123,13 +123,13 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "group_contests", ["contest_id", "group_id"], name: "index_group_contests_on_contest_id_and_group_id", using: :btree
   add_index "group_contests", ["group_id", "contest_id"], name: "index_group_contests_on_group_id_and_contest_id", using: :btree
 
-  create_table "group_memberships", force: true do |t|
+  create_table "group_memberships", force: :cascade do |t|
     t.integer  "group_id"
     t.integer  "member_id"
     t.datetime "created_at"
   end
 
-  create_table "group_problem_sets", force: true do |t|
+  create_table "group_problem_sets", force: :cascade do |t|
     t.integer "group_id"
     t.integer "problem_set_id"
     t.string  "name"
@@ -138,7 +138,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "group_problem_sets", ["group_id", "problem_set_id"], name: "index_group_problem_sets_on_group_id_and_problem_set_id", using: :btree
   add_index "group_problem_sets", ["problem_set_id", "group_id"], name: "index_group_problem_sets_on_problem_set_id_and_group_id", using: :btree
 
-  create_table "groups", force: true do |t|
+  create_table "groups", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -147,7 +147,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.integer  "membership", default: 0, null: false
   end
 
-  create_table "item_histories", force: true do |t|
+  create_table "item_histories", force: :cascade do |t|
     t.integer  "item_id"
     t.boolean  "active"
     t.integer  "action"
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.datetime "updated_at"
   end
 
-  create_table "items", force: true do |t|
+  create_table "items", force: :cascade do |t|
     t.integer "product_id"
     t.integer "owner_id"
     t.integer "organisation_id"
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.integer "scan_token"
   end
 
-  create_table "language_groups", force: true do |t|
+  create_table "language_groups", force: :cascade do |t|
     t.string   "identifier"
     t.string   "name"
     t.integer  "current_language_id"
@@ -180,7 +180,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
 
   add_index "language_groups", ["identifier"], name: "index_language_groups_on_identifier", unique: true, using: :btree
 
-  create_table "languages", force: true do |t|
+  create_table "languages", force: :cascade do |t|
     t.string   "identifier"
     t.string   "compiler"
     t.boolean  "interpreted"
@@ -201,17 +201,17 @@ ActiveRecord::Schema.define(version: 20200418113601) do
 
   add_index "languages", ["identifier"], name: "index_languages_on_identifier", unique: true, using: :btree
 
-  create_table "organisations", force: true do |t|
+  create_table "organisations", force: :cascade do |t|
   end
 
-  create_table "problem_series", force: true do |t|
+  create_table "problem_series", force: :cascade do |t|
     t.string "name"
     t.string "identifier"
     t.string "importer_type"
     t.text   "index_yaml"
   end
 
-  create_table "problem_set_problems", force: true do |t|
+  create_table "problem_set_problems", force: :cascade do |t|
     t.integer "problem_set_id"
     t.integer "problem_id"
     t.integer "problem_set_order"
@@ -221,7 +221,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "problem_set_problems", ["problem_id", "problem_set_id"], name: "index_problem_set_problems_on_problem_id_and_problem_set_id", using: :btree
   add_index "problem_set_problems", ["problem_set_id", "problem_id"], name: "index_problem_set_problems_on_problem_set_id_and_problem_id", using: :btree
 
-  create_table "problem_sets", force: true do |t|
+  create_table "problem_sets", force: :cascade do |t|
     t.string   "name"
     t.integer  "owner_id"
     t.datetime "created_at"
@@ -229,7 +229,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.integer  "finalized_contests_count", default: 0
   end
 
-  create_table "problems", force: true do |t|
+  create_table "problems", force: :cascade do |t|
     t.string   "name"
     t.text     "statement"
     t.string   "input"
@@ -246,44 +246,44 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.integer  "test_status",        default: 0
   end
 
-  create_table "products", force: true do |t|
+  create_table "products", force: :cascade do |t|
     t.string  "name"
     t.integer "gtin",        limit: 8
     t.text    "description"
     t.string  "image"
   end
 
-  create_table "requests", force: true do |t|
+  create_table "requests", force: :cascade do |t|
     t.integer  "requester_id"
     t.integer  "subject_id"
     t.string   "subject_type"
-    t.string   "verb",                            null: false
-    t.integer  "target_id",                       null: false
-    t.string   "target_type",                     null: false
-    t.integer  "status",       default: 0,        null: false
+    t.string   "verb",                              null: false
+    t.integer  "target_id",                         null: false
+    t.string   "target_type",                       null: false
+    t.integer  "status",       default: 0,          null: false
     t.integer  "requestee_id"
-    t.datetime "expired_at",   default: Infinity, null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "expired_at",   default: 'Infinity', null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
   end
 
-  create_table "roles", force: true do |t|
+  create_table "roles", force: :cascade do |t|
     t.string "name"
   end
 
-  create_table "roles_users", id: false, force: true do |t|
+  create_table "roles_users", id: false, force: :cascade do |t|
     t.integer "role_id"
     t.integer "user_id"
   end
 
-  create_table "schools", force: true do |t|
+  create_table "schools", force: :cascade do |t|
     t.string  "name"
     t.string  "country_code", limit: 2
     t.integer "users_count"
     t.integer "synonym_id"
   end
 
-  create_table "sessions", force: true do |t|
+  create_table "sessions", force: :cascade do |t|
     t.string   "session_id", null: false
     t.text     "data"
     t.datetime "created_at"
@@ -294,14 +294,14 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
-  create_table "settings", force: true do |t|
+  create_table "settings", force: :cascade do |t|
     t.string "key"
     t.string "value"
   end
 
   add_index "settings", ["key"], name: "index_settings_on_key", unique: true, using: :btree
 
-  create_table "submissions", force: true do |t|
+  create_table "submissions", force: :cascade do |t|
     t.text     "source"
     t.integer  "score"
     t.integer  "user_id"
@@ -325,7 +325,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "submissions", ["problem_id", "created_at"], name: "index_submissions_on_problem_id_and_created_at", using: :btree
   add_index "submissions", ["user_id", "problem_id"], name: "index_submissions_on_user_id_and_problem_id", using: :btree
 
-  create_table "test_case_relations", force: true do |t|
+  create_table "test_case_relations", force: :cascade do |t|
     t.integer  "test_case_id"
     t.integer  "test_set_id"
     t.datetime "created_at",   null: false
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "test_case_relations", ["test_case_id"], name: "index_test_case_relations_on_test_case_id", using: :btree
   add_index "test_case_relations", ["test_set_id"], name: "index_test_case_relations_on_test_set_id", using: :btree
 
-  create_table "test_cases", force: true do |t|
+  create_table "test_cases", force: :cascade do |t|
     t.text     "input"
     t.text     "output"
     t.string   "name"
@@ -348,7 +348,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
 
   add_index "test_cases", ["problem_id", "name"], name: "index_test_cases_on_problem_id_and_name", unique: true, using: :btree
 
-  create_table "test_sets", force: true do |t|
+  create_table "test_sets", force: :cascade do |t|
     t.integer  "problem_id"
     t.integer  "points"
     t.string   "name"
@@ -360,7 +360,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
 
   add_index "test_sets", ["problem_id", "name"], name: "index_test_sets_on_problem_id_and_name", unique: true, using: :btree
 
-  create_table "user_problem_relations", force: true do |t|
+  create_table "user_problem_relations", force: :cascade do |t|
     t.integer  "problem_id"
     t.integer  "user_id"
     t.integer  "submissions_count"
@@ -376,7 +376,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
   add_index "user_problem_relations", ["problem_id", "ranked_score"], name: "index_user_problem_relations_on_problem_id_and_ranked_score", using: :btree
   add_index "user_problem_relations", ["user_id", "problem_id"], name: "index_user_problem_relations_on_user_id_and_problem_id", unique: true, using: :btree
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "email",                            default: "",    null: false
     t.string   "encrypted_password",               default: "",    null: false
     t.string   "reset_password_token"


### PR DESCRIPTION
By updating the rails version, we now get a slightly different dump format. In practise, this is the same effective result, but we should commit this new version to:
(a) ensure everyone is definitely loading the right thing when using
    schema:load
(b) prevent diff's when doing a deploy which is just scary looking for
    now reason.