### PR TITLE
Avoid initialising qless if running an unsupported Redis version

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -26,8 +26,11 @@ $redis = Redis.new(REDIS_CONFIG)
 # To clear out the db before each test
 $redis.flushdb if Rails.env == "test"
 
-$qless = Qless::Client.new(REDIS_CONFIG.merge(:redis => $redis))
-$qless.config['heartbeat'] = 1800
+if $redis.info["redis_version"].to_f < 6.2
+  $qless = Qless::Client.new(REDIS_CONFIG.merge(:redis => $redis))
+  $qless.config['heartbeat'] = 1800
+end
+
 # To use Redis::Objects
 #require 'redis/objects'
 #Redis::Objects.redis = $redis


### PR DESCRIPTION
A lot of general development doesn't require qless, and running these
older versions of Redis on macOS is kinda difficult.
