### PR TITLE
Setup capistrano for deployments

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,38 @@
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy"
+
+# Load the SCM plugin appropriate to your project:
+#
+# require "capistrano/scm/hg"
+# install_plugin Capistrano::SCM::Hg
+# or
+# require "capistrano/scm/svn"
+# install_plugin Capistrano::SCM::Svn
+# or
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
+# Include tasks from other gems included in your Gemfile
+#
+# For documentation on these, see for example:
+#
+#   https://github.com/capistrano/rvm
+#   https://github.com/capistrano/rbenv
+#   https://github.com/capistrano/chruby
+#   https://github.com/capistrano/bundler
+#   https://github.com/capistrano/rails
+#   https://github.com/capistrano/passenger
+#
+# require "capistrano/rvm"
+require "capistrano/rbenv"
+# require "capistrano/chruby"
+require "capistrano/bundler"
+require "capistrano/rails/assets"
+require "capistrano/rails/migrations"
+require "capistrano/passenger"
+
+# Load custom tasks from `lib/capistrano/tasks` if you have any defined
+Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,13 @@ gem 'connection_pool'
 gem 'sinatra'
 
 # Deploy with Capistrano
-# gem 'capistrano'
+group :development do
+  gem 'capistrano', '~> 3.17', require: false
+  gem 'capistrano-bundler', '~> 2.0', require: false
+  gem 'capistrano-passenger', require: false
+  gem 'capistrano-rbenv', '~> 2.2'
+  gem "capistrano-rails", "~> 1.6", require: false
+end
 
 # Monitoring
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     afm (0.2.2)
+    airbrussh (1.5.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.4)
     ast (2.4.2)
     atomic (1.1.101)
@@ -56,6 +58,21 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
     byebug (9.1.0)
+    capistrano (3.18.0)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (2.1.0)
+      capistrano (~> 3.1)
+    capistrano-passenger (0.2.1)
+      capistrano (~> 3.0)
+    capistrano-rails (1.6.3)
+      capistrano (~> 3.1)
+      capistrano-bundler (>= 1.1, < 3)
+    capistrano-rbenv (2.2.0)
+      capistrano (~> 3.1)
+      sshkit (~> 1.3)
     capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -189,9 +206,13 @@ GEM
       i18n (>= 0.6.4, < 1.0)
     multi_json (1.15.0)
     multipart-post (2.0.0)
+    mutex_m (0.1.2)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-ssh (6.1.0)
     newrelic_rpm (4.7.1.340)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -365,6 +386,10 @@ GEM
       activerecord (>= 3.0)
       activesupport (>= 3.0)
       polyamorous (~> 1.1.0)
+    sshkit (1.21.7)
+      mutex_m
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     ssrf_filter (1.0.8)
     standard (0.2.5)
       rubocop (~> 0.80.1)
@@ -423,6 +448,11 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   byebug
+  capistrano (~> 3.17)
+  capistrano-bundler (~> 2.0)
+  capistrano-passenger
+  capistrano-rails (~> 1.6)
+  capistrano-rbenv (~> 2.2)
   capybara
   capybara-email
   carrierwave (= 1.3.2)
@@ -488,4 +518,4 @@ RUBY VERSION
    ruby 2.4.10p364
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,39 @@
+# config valid for current version and patch releases of Capistrano
+lock "~> 3.18.0"
+
+set :application, "nztrain"
+set :repo_url, "git@github.com:NZOI/nztrain.git"
+
+# Default branch is :master
+# ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+
+# Default deploy_to directory is /var/www/my_app_name
+# set :deploy_to, "/var/www/my_app_name"
+
+# Default value for :format is :airbrussh.
+# set :format, :airbrussh
+
+# You can configure the Airbrussh format using :format_options.
+# These are the defaults.
+# set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
+
+# Default value for :pty is false
+# set :pty, true
+
+# Default value for :linked_files is []
+append :linked_files, "config/database.yml", "config/redis.yml"
+
+# Default value for linked_dirs is []
+append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system", "vendor", "storage", ".bundle"
+
+# Default value for default_env is {}
+# set :default_env, { path: "/opt/ruby/bin:$PATH" }
+
+# Default value for local_user is ENV['USER']
+# set :local_user, -> { `git config user.name`.chomp }
+
+# Default value for keep_releases is 5
+# set :keep_releases, 5
+
+# Uncomment the following to require manually verifying the host key before first deploy.
+# set :ssh_options, verify_host_key: :secure

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,0 +1,57 @@
+# server-based syntax
+# ======================
+# Defines a single server with a list of roles and multiple properties.
+# You can define all roles on a single server, or split them:
+
+# server "train.nzoi.org.nz", user: "cap_deploy", roles: %w[app db web]
+server "faketrain", user: "cap_deploy", roles: %w[app db web]
+# server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
+# server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
+# server "db.example.com", user: "deploy", roles: %w{db}
+
+# role-based syntax
+# ==================
+
+# Defines a role with one or multiple servers. The primary server in each
+# group is considered to be the first unless any hosts have the primary
+# property set. Specify the username and a domain or IP for the server.
+# Don't use `:all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}, my_property: :my_value
+# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
+# role :db,  %w{deploy@example.com}
+
+# Configuration
+# =============
+# You can set any configuration variable like in config/deploy.rb
+# These variables are then only loaded and set in this stage.
+# For available Capistrano configuration variables see the documentation page.
+# http://capistranorb.com/documentation/getting-started/configuration/
+# Feel free to add new variables to customise your setup.
+
+# Custom SSH Options
+# ==================
+# You may pass any option but keep in mind that net/ssh understands a
+# limited set of options, consult the Net::SSH documentation.
+# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
+#
+# Global options
+# --------------
+#  set :ssh_options, {
+#    keys: %w(/home/user_name/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+#
+# The server-based syntax can be used to override options:
+# ------------------------------------
+# server "example.com",
+#   user: "user_name",
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: "user_name", # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: "please use keys"
+#   }


### PR DESCRIPTION
The current deployment process doesn't give us many options for
rollbacks, and could have issues if the server was restarted during the
deployment. Most rails apps that aren't containerised tend to be
deployed with Capistrano [1].

Capistrano lets us all the same user, and manage deployment access by
giving people access to the deploy user by adding their ssh public key.
We should be able to move towards that being a sudo-less enterprise, but
qless may make that difficult.