### PR TITLE
Unpin Redis version

### DIFF
--- a/script/install/redis.bash
+++ b/script/install/redis.bash
@@ -19,10 +19,7 @@ redis-server --version 2>/dev/null | bash script/extract_version.bash | bash scr
   apt-get install chkconfig
 
   # install redis
-  # version temporarily locked to 6.2.6, because 7.0+ and 6.2.7+ break qless
-  # see https://github.com/seomoz/qless-core/issues/89
-  # TODO: once that issue is fixed, "--version ..." can be removed to switch back to "stable"
-  bash "`dirname $0`/redis-installer.bash" --version 6.2.6
+  bash "`dirname $0`/redis-installer.bash"
   result=$?
 
   if [[ "$result" -eq 0 ]] ; then


### PR DESCRIPTION
Merge after ~~#224~~. *Merged.*

We have switched (#224) to the Shopify fork of qless, which supports Redis >= 6.2.7 [1], so we can now use Redis stable again.

Reverts #156.

[1] https://www.github.com/Shopify/qless/pull/39