### PR TITLE
Make /users etc. twice as fast by preloading roles

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,19 +1,19 @@
 class UsersController < ApplicationController
   def index
     authorize User.new, :index?
-    @users = policy_scope(User).num_solved.order(:email)
+    @users = policy_scope(User).num_solved.includes(:roles).order(:email)
     render
   end
 
   def online
     authorize User.new, :inspect?
-    @users = policy_scope(User).order(:last_seen_at).reverse_order
+    @users = policy_scope(User).includes(:roles).order(:last_seen_at).reverse_order
     render
   end
 
   def newest
     authorize User.new, :inspect?
-    @users = policy_scope(User).order(:created_at).reverse_order.limit(100)
+    @users = policy_scope(User).includes(:roles).order(:created_at).reverse_order.limit(100)
     render
   end
 


### PR DESCRIPTION
From the commit message:

> This is an example of the N+1 query problem. Fixing it makes the pages render about twice as fast when there are many (thousands) of users.
> 
> The rest of the time is spent in the view, which is harder to optimise (there are some low-hanging fruit such as caching the policies, but they'll only get us so far; the only complete solution is to introduce paging).
> 
> See: #192
> 
> Reported-by: @thebrucecgit (and others)

For testing, the following snippet can be used to populate the database with 10,000 users:

```ruby
def create_user(id)
  attrs = {username: "u#{id}", email: "u#{id}@example.com", name: "U#{id}", confirmed_at: Time.now.utc}
  User.new(attrs).save!(validate: false)
end

User.transaction { (User.count + 1).upto(10000) { |i| create_user(i) } }
```

I suggest running it using `rails runner '...'` rather than `rails console`, so it won't spam the terminal with log messages.

---

If anyone has ideas on how to make the view even faster (without resorting to paging), please chime in! The relevant code is in [app/views/users/index.html.erb](https://github.com/NZOI/nztrain/blob/5a712db9966350b7046b8523d0b581f508e270c5/app/views/users/index.html.erb#L31:L55). I have a draft patch that caches the policies in branch [users-index-faster-cache-policies](https://github.com/NZOI/nztrain/commit/ed8c68f435c6708331d840fad8adc0fa6cf7f766), but it doesn't make that much difference. I suspect we'll have to switch to paging.