### PR TITLE
Extend duration of 'remember me' cookie

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -100,10 +100,10 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 1.month
 
   # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set
   # :secure => true in order to force SSL only cookies.


### PR DESCRIPTION
Untested, creating this so we won't forget. It came up in #162.

The 1 month is mostly arbitrary, happy to change it. (I thought 1 month is long enough for regular users, and that if someone has been away >1 month then it's fair to sign them out.)

I'm not completely certain how Devise behaves; my commit message might be inaccurate.