### PR TITLE
Fix /file_attachments page

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -16,7 +16,7 @@ class FileAttachmentsController < ApplicationController
       @file_attachments = FileAttachment.where(:owner_id => current_user.id)
     else
       authorize FileAttachment.new, :manage?
-      @file_attachments = FileAttachment.scoped
+      @file_attachments = FileAttachment.all
     end
   end
 


### PR DESCRIPTION
`Model.scoped` was deprecated in favour of `Model.all` in Rails 4.0 [1], and removed in Rails 4.1 [2].

[1] https://github.com/rails/rails/blob/v4.0.13/activerecord/CHANGELOG.md?plain=1#L2698-L2714
[2] https://github.com/rails/rails/blob/v4.1.16/activerecord/CHANGELOG.md?plain=1#L2338