### PR TITLE
Add a tiny spec for the file attachments page

### DIFF
--- a/spec/controllers/file_attachments_controller_spec.rb
+++ b/spec/controllers/file_attachments_controller_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe FileAttachmentsController do
+  describe "GET /file_attachments" do
+    before do
+      sign_in users(:superadmin)
+    end
+
+    can_index :file_attachments
+  end
+end


### PR DESCRIPTION
This broke in the rails upgrade, so following the convention of "fix a
bug, add a spec" - here's a tiny spec that was failing before the fix in
dbe5f381c577ef922ce2edd60e9dbda86ab6304b and is now passing thanks to
that commit.
