### PR TITLE
Bump bcrypt from 3.1.11 to 3.1.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     backup (3.4.0)
       open4 (~> 1.3.0)
       thor (>= 0.15.4, < 2)
-    bcrypt (3.1.11)
+    bcrypt (3.1.20)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)


### PR DESCRIPTION
Extracted from #223 (because this is also important outside CI) and added links to commit message:

> This fixes the following error during `rake db:seed` on Ubuntu 20.04:
> 
> BCrypt::Errors::InvalidHash (invalid hash)
> 
> See:
> https://www.github.com/heartcombo/devise/issues/4861
> https://www.github.com/bcrypt-ruby/bcrypt-ruby/issues/165
> https://www.github.com/bcrypt-ruby/bcrypt-ruby/pull/164