### PR TITLE
Prevent other users from executing 'isolate'

### DIFF
--- a/script/install/isolate.bash
+++ b/script/install/isolate.bash
@@ -25,3 +25,6 @@ make install || {
   rm -r isolate
   exit 1
 }
+
+chgrp "$APP_USER" /usr/local/bin/isolate || exit 1
+chmod 4750 /usr/local/bin/isolate || exit 1 # change permissions from default (4755) to prevent other users from executing, because it is setuid


### PR DESCRIPTION
When we updated to latest version of isolate (#176), the permissions changed from 4750 to 4755 (the upstream default, allowing all users to read/execute).

On further thought, it's probably safer to prevent other users from executing isolate, just because it's setuid.