### PR TITLE
Use correct group name for isolate/isolock

### DIFF
--- a/script/install.cfg.template
+++ b/script/install.cfg.template
@@ -14,6 +14,7 @@ export APP_NAME=${APP_NAME}
 # Rails environment that will be used to run this installation
 export RAILS_ROOT=${RAILS_ROOT}
 export APP_USER=${APP_USER} # user this app will run under
+export APP_GROUP=${APP_GROUP} # group this app will run under
 export RAILS_ENV=${RAILS_ENV} # development or production
 
 # Unicorn

--- a/script/install/config.bash
+++ b/script/install/config.bash
@@ -57,6 +57,13 @@ while [ -z "$APP_USER" ] ; do
   if [[ ! $APP_USER ]] ; then APP_USER=$USER ; fi
 done
 
+default_app_group="$(id -gn "$APP_USER")"
+while [ -z "$APP_GROUP" ] ; do
+  anyset=true
+  prompt "What group will the server run as (default=$default_app_group)? " APP_GROUP
+  if [[ ! $APP_GROUP ]] ; then APP_GROUP=$default_app_group ; fi
+done
+
 while [ -z "$RAILS_ENV" ] ; do
   anyset=true
   prompt 'What environment is used to run this rails installation - d[evelopment] (default), p[roduction] or t[est]? ' RAILS_ENV
@@ -202,7 +209,7 @@ declare -p ISOLATE_BRANCH &> /dev/null || ISOLATE_BRANCH=master # no prompt
 shopt -u nocasematch;
 
 if $anyset ; then
-  export SERVER_NAME APP_NAME RAILS_ROOT APP_USER RAILS_ENV UNICORN_PORT
+  export SERVER_NAME APP_NAME RAILS_ROOT APP_USER APP_GROUP RAILS_ENV UNICORN_PORT
   export DATABASE TEST_DATABASE DATABASE_USERNAME
   export REDIS_HOST REDIS_PORT REDIS_PASS REDIS_INSTALL
   export SCHEDULE_BACKUPS BACKUP_RSYNC BACKUP_RSYNC_MODE BACKUP_RSYNC_PORT BACKUP_RSYNC_HOST BACKUP_RSYNC_USER BACKUP_RSYNC_PASS BACKUP_RSYNC_SSH_KEY BACKUP_RSYNC_PATH

--- a/script/install/config.bash
+++ b/script/install/config.bash
@@ -53,7 +53,7 @@ fi
 
 while [ -z "$APP_USER" ] ; do
   anyset=true
-  prompt "What username should the server run as (default=$USER)? " APP_USER
+  prompt "What username will the server run as (default=$USER)? " APP_USER
   if [[ ! $APP_USER ]] ; then APP_USER=$USER ; fi
 done
 

--- a/script/install/isolate.bash
+++ b/script/install/isolate.bash
@@ -26,5 +26,5 @@ make install || {
   exit 1
 }
 
-chgrp "$APP_USER" /usr/local/bin/isolate || exit 1
+chgrp "$APP_GROUP" /usr/local/bin/isolate || exit 1
 chmod 4750 /usr/local/bin/isolate || exit 1 # change permissions from default (4755) to prevent other users from executing, because it is setuid

--- a/script/install/isolock.bash
+++ b/script/install/isolock.bash
@@ -16,7 +16,7 @@ else
   git clone https://github.com/NZOI/isolock.git && cd isolock || exit 1
 fi
 
-make && chown root bin/isolock && chgrp $APP_USER bin/isolock && chmod 6750 bin/isolock || {
+make && chown root bin/isolock && chgrp "$APP_GROUP" bin/isolock && chmod 6750 bin/isolock || {
   echo "Failure to setup isolock permissions - aborting"
   cd ..
   rm -r $srclocation/isolock

--- a/script/install/isolock.bash
+++ b/script/install/isolock.bash
@@ -16,7 +16,7 @@ else
   git clone https://github.com/NZOI/isolock.git && cd isolock || exit 1
 fi
 
-make && chown root bin/isolock && chgrp "$APP_GROUP" bin/isolock && chmod 6750 bin/isolock || {
+make && chown root bin/isolock && chgrp "$APP_GROUP" bin/isolock && chmod 4750 bin/isolock || {
   echo "Failure to setup isolock permissions - aborting"
   cd ..
   rm -r $srclocation/isolock


### PR DESCRIPTION
Previously the scripts assumed that the group name is the same as the username, but that's not necessarily the case.

This came up in #223.

Merge using "rebase".
