### PR TITLE
Update config.serve_static_assets to config.serve_static_files

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ NZTrain::Application.configure do
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
-  config.serve_static_file = true # true so Webrick testing of production mode works
+  config.serve_static_files = true # true so Webrick testing of production mode works
 
   # Enable serving of images, stylesheets, and javascripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ NZTrain::Application.configure do
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
-  config.serve_static_assets = true # true so Webrick testing of production mode works
+  config.serve_static_file = true # true so Webrick testing of production mode works
 
   # Enable serving of images, stylesheets, and javascripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,7 +34,7 @@ NZTrain::Application.configure do
   config.active_support.deprecation = :stderr
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Raise exception on mass assignment protection for Active Record models


### PR DESCRIPTION
This option is deprecated in Rails 4.2 and removed in Rails 5. There isn't a lot of rational explained in the MR, but hey.

[1] https://github.com/rails/rails/pull/18100
[2] https://github.com/rails/rails/commit/463b5d7581ee16bfaddf34ca349b7d1b5878097c