### PR TITLE
Send deprecation notices to the rails log

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ NZTrain::Application.configure do
   config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners
-  config.active_support.deprecation = :notify
+  config.active_support.deprecation = :log
 
   # Compress JavaScript and CSS  
   config.assets.compress = true  


### PR DESCRIPTION
Prior to this change, messages were being send to the ActiveSupport::Notifications system which doesn't appear to have any active listeners, meaning these notices were just being sent into the void. The notification was probably setup for a old integration (maybe newrelic?) but nothing appears to be using it at the moment.