### PR TITLE
Remove nokogiri dependency packages

### DIFF
--- a/script/install.bash
+++ b/script/install.bash
@@ -40,8 +40,6 @@ bash script/install/nztrain.bash || exit 1 # fix files & directory structure
 
 bash script/install/bundler.bash || exit 1
 
-bash script/install/nokogiri.bash || exit 1 # nokogiri dependencies
-
 bash script/install/jdk.bash || exit 1 # required by yui-compressor
 
 sudo bash script/install/isolate.bash || exit 1 # install isolate

--- a/script/install/nokogiri.bash
+++ b/script/install/nokogiri.bash
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-cmd="sudo apt-get install libxslt-dev libxml2-dev"
-
-echo "$ $cmd"
-$cmd
-


### PR DESCRIPTION
As of Nokogiri 1.6, libxml2 and libxslt are bundled with Nokogiri [1], so we don't need to install the header files.

[1] https://github.com/sparklemotion/nokogiri/blob/v1.6.8.1/CHANGELOG.rdoc#label-1.6.0.rc1+-2F+2013-04-14