### PR TITLE
Restore :assets group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,19 +89,19 @@ group :development, :test do
 end
 
 
-# Gems used only for assets and not required  
-# in production environments by default.  
-#group :assets do  
-gem 'sass'
-gem 'sass-rails'
-gem 'coffee-rails'
-gem 'uglifier', '>=1.0.3'
-# Provide a JS runtime to execjs without needing to
-# have node, bun, or similar installed on the relevant
-# server. We should write this out asap, along with the
-# rest of the gems in this assets category, as bundling
-# a version of libv8 into a rubygem is just security-vuln
-# city, but hey, what can you do.
-gem 'mini_racer', '~> 0.4.0'
-gem 'yui-compressor'
-#end
+# Gems used only for precompiling assets. They may be skipped using
+# `export BUNDLE_WITHOUT=assets` or `bundle config --local without assets`.
+group :assets do
+  gem 'sass'
+  gem 'sass-rails'
+  gem 'coffee-rails'
+  gem 'uglifier', '>=1.0.3'
+  # Provide a JS runtime to execjs without needing to
+  # have node, bun, or similar installed on the relevant
+  # server. We should write this out asap, along with the
+  # rest of the gems in this assets category, as bundling
+  # a version of libv8 into a rubygem is just security-vuln
+  # city, but hey, what can you do.
+  gem 'mini_racer', '~> 0.4.0'
+  gem 'yui-compressor'
+end


### PR DESCRIPTION
**TODO:** https://github.com/NZOI/nztrain/pull/250#issuecomment-1879579742

Some of those gems (especially mini_racer) are very large, and it is useful to be able to skip them. They were already in a commented-out group; restore the group to allow skipping them (they will still be installed by default).

Note that putting them in a group will mean they won't be auto-required when config/application.rb calls
`Bundler.require(:default, Rails.env)`, but that should be fine.

Also remove the old comment "not required in production environments by default" because it is unclear/inaccurate (we currently run the asset precompilation on the production server), and add hints on how to skip the group.