### PR TITLE
Switch to default-jre-headless on server for yui-compressor

### DIFF
--- a/script/install.bash
+++ b/script/install.bash
@@ -40,7 +40,7 @@ bash script/install/nztrain.bash || exit 1 # fix files & directory structure
 
 bash script/install/bundler.bash || exit 1
 
-bash script/install/jdk.bash || exit 1 # required by yui-compressor
+bash script/install/jre.bash || exit 1 # required by yui-compressor
 
 sudo bash script/install/isolate.bash || exit 1 # install isolate
 sudo bash script/install/cgroup.bash || exit 1 # install cgroups

--- a/script/install/jre.bash
+++ b/script/install/jre.bash
@@ -10,7 +10,7 @@
 #  } || exit 1
 #}
 
-cmd="sudo apt-get install openjdk-8-jdk" # java required by yui-compressor gem
+cmd="sudo apt-get install default-jre-headless" # java required by yui-compressor gem
 echo "$ $cmd"
 $cmd
 [[ $? -le 1 ]] || exit 1 # apt-get exit 0 = success, 1 = decline, otherwise unknown error

--- a/script/install/jre.bash
+++ b/script/install/jre.bash
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-#min_version=6
-#convert -version 2>/dev/null | bash script/extract_version.bash | bash script/check_version.bash $min_version || { # already installed
-#  echo ImageMagick $min_version+ required!
-#  bash script/confirm.bash "Install ImageMagick" && {
-#    cmd="sudo apt-get install imagemagick"
-#    echo "$ $cmd"
-#    $cmd
-#  } || exit 1
-#}
-
 cmd="sudo apt-get install default-jre-headless" # java required by yui-compressor gem
 echo "$ $cmd"
 $cmd


### PR DESCRIPTION
Was previously openjdk-8-jdk.

 - yui-compressor only requires the JRE, not the full JDK

 - GUI libraries aren't required, headless version is enough

 - the JRE version doesn't really matter, use the default so it gets
   automatically updated

Also remove unrelated commented-out lines from JRE install script.