### PR TITLE
Add system/mailer settings to db/seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ if rootuser && rootuser.username == "root"
   superadmin.users.push(rootuser) unless superadmin.users.include?(rootuser);
 end
 
-["recaptcha/public_key","recaptcha/private_key"].each do |setting|
+["recaptcha/public_key", "recaptcha/private_key", "system/mailer/username", "system/mailer/password"].each do |setting|
   Setting.find_or_create_by(key: setting)
 end
 


### PR DESCRIPTION
> These are currently created during migrations, but we plan to remove this behaviour in #243. The values are left blank, as they need to be set manually anyway.

@tom93 suggested using an environment variable for the password; I didn't bother, but feel free to add that if you prefer.

Commit message can be changed if we decide not to go with #243.