### PR TITLE
Skip wkhtmltopdf in CI

### DIFF
--- a/script/install.bash
+++ b/script/install.bash
@@ -34,7 +34,7 @@ bash script/install/postgresql.bash || exit 1 # create user & db if it doesn't e
 
 bash script/install/imagemagick.bash || exit 1 # install imagemagick
 
-sudo apt-get install wkhtmltopdf xvfb || exit 1
+[ -n "$CI" ] || sudo apt-get install wkhtmltopdf xvfb || exit 1 # for pdfkit; skip in CI
 
 bash script/install/nztrain.bash || exit 1 # fix files & directory structure
 

--- a/script/install.bash
+++ b/script/install.bash
@@ -34,7 +34,7 @@ bash script/install/postgresql.bash || exit 1 # create user & db if it doesn't e
 
 bash script/install/imagemagick.bash || exit 1 # install imagemagick
 
-[ -n "$CI" ] || sudo apt-get install wkhtmltopdf xvfb || exit 1 # for pdfkit; skip in CI
+[ -n "$CI" ] || bash script/install/wkhtmltopdf.bash || exit 1 # for pdfkit; skip in CI
 
 bash script/install/nztrain.bash || exit 1 # fix files & directory structure
 

--- a/script/install/wkhtmltopdf.bash
+++ b/script/install/wkhtmltopdf.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cmd="sudo apt-get install wkhtmltopdf xvfb"
+echo "$ $cmd"
+$cmd || exit 1


### PR DESCRIPTION
It is used by the PDFKit gem, which is only used from app/views/item/label.html.erb. That view is not tested, so we can make
CI faster by skipping the install of wkhtmltopdf. (We can add it back if/when we write a test for the view.)
