### PR TITLE
Render 404 Not Found for invalid problem filelink path

### DIFF
--- a/app/controllers/filelinks/roots_controller.rb
+++ b/app/controllers/filelinks/roots_controller.rb
@@ -56,7 +56,7 @@ class Filelinks::RootsController < ApplicationController
     else
       raise ActiveRecord::RecordNotFound if params[:filepath].nil?
       filepath = [params[:filepath], params[:format]].compact.join('.')
-      @filelink = model.filelinks.find_by_filepath(filepath)
+      @filelink = model.filelinks.find_by_filepath!(filepath)
     end
     authorize @filelink, :show?
     send_file FileAttachmentUploader.root + @filelink.file_attachment_url, :filename => File.basename(@filelink.filepath), :disposition => 'inline'


### PR DESCRIPTION
(Minor)

Previously, /problems/:id/files/download/:path with a non-existent path would crash with Pundit::NotDefinedError (unable to find policy of nil), because `find_by_filepath` returns nil if the record is not found and then `authorize @filelink, :show?` fails.