### PR TITLE
Add support for custom evaluators using compiled langauges

### DIFF
--- a/app/assets/stylesheets/submission.css
+++ b/app/assets/stylesheets/submission.css
@@ -19,6 +19,7 @@ table.results {
   border-spacing: 0;
   border-collapse: collapse;
   width: 100%;
+  margin: 15px 0px;
 }
 
 .results th {

--- a/app/controllers/evaluators_controller.rb
+++ b/app/controllers/evaluators_controller.rb
@@ -2,7 +2,7 @@ class EvaluatorsController < ApplicationController
 
   def permitted_params
     @_permitted_params ||= begin
-      permitted_attributes = [:name, :description, :source]
+      permitted_attributes = [:name, :description, :source, :language_id]
       permitted_attributes << :owner_id if policy(@evaluator || Evaluator).transfer?
       params.require(:evaluator).permit(*permitted_attributes)
     end

--- a/app/models/evaluator.rb
+++ b/app/models/evaluator.rb
@@ -3,6 +3,7 @@ class Evaluator < ActiveRecord::Base
 
   has_many :problems
   belongs_to :owner, :class_name => :User
+  belongs_to :language
 
   validates :name, :presence => true
 

--- a/app/models/submission/judge_data.rb
+++ b/app/models/submission/judge_data.rb
@@ -285,8 +285,16 @@ class Submission
       data.has_key?('compile')
     end
 
+    def evaluator_compiled?
+      data.has_key?('evaluator_compile')
+    end
+
     def compilation
       @compilation ||= Compilation.new(data['compile'])
+    end
+
+    def evaluator_compilation
+      @evaluator_compilation ||= Compilation.new(data['evaluator_compile'])
     end
 
     def prerequisite_sets

--- a/app/views/evaluators/_form.html.erb
+++ b/app/views/evaluators/_form.html.erb
@@ -24,6 +24,10 @@
     <%= f.text_area :source %>
   </div>
   <div class="field">
+    <%= f.label :language_id %><br>
+    <%= f.select :language_id, grouped_options_for_select(Language.grouped_submission_options, @evaluator.language_id), :include_blank => true %>
+  </div>
+  <div class="field">
     <%= f.label :owner_id %><br />
     <% if policy(@evaluator).transfer? %>
       <%= f.text_field :owner_id %>

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -7,6 +7,7 @@
       <th>Name</th>
       <th>Description</th>
       <th>User</th>
+      <th>Langauge</th>
       <th></th>
       <% if policy(Evaluator).update? %>
         <th></th>
@@ -22,6 +23,7 @@
     <td><%= evaluator.name %></td>
     <td><%= evaluator.description %></td>
     <td><%= evaluator.owner_id %></td>
+    <td><%= evaluator.language&.name %></td>
     <td><%= link_to 'Show', evaluator %></td>
     <% if policy(Evaluator).update? %>
       <td><%= link_to 'Edit', edit_evaluator_path(evaluator) if policy(evaluator).update? %></td>

--- a/app/views/evaluators/show.html.erb
+++ b/app/views/evaluators/show.html.erb
@@ -8,8 +8,10 @@
 </p>
 <% if policy(@evaluator).inspect? %>
   <p>
+    <b>Language:</b>
+    <%= @evaluator.language&.name %><br>
     <b>Source:</b>
-    <pre><%= @evaluator.source %></pre>
+    <%= predisplay @evaluator.source, language: @evaluator.language&.lexer %>
   </p>
 <% end %>
 

--- a/app/views/problems/_admin.html.erb
+++ b/app/views/problems/_admin.html.erb
@@ -54,7 +54,7 @@
   <% if @problem.evaluator %>
     <%= link_to @problem.evaluator.name, @problem.evaluator %>
     <% if policy(@problem.evaluator).inspect? # privilege required to see evaluator source %>
-      <%= predisplay @problem.evaluator.source, language: :sh %>
+      <%= predisplay @problem.evaluator.source, language: @problem.evaluator.language&.lexer %>
     <% end %>
   <% else %>
     Default evaluator

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -47,8 +47,8 @@
 </p>
 
 <% @judge_data = @submission.judge_data %>
-<table class="results">
-  <% if @judge_data.compiled? %>
+<% if @judge_data.compiled? %>
+  <table class="results">
     <tbody class="compilation status_<%= @judge_data.compilation.status %>">
       <tr>
         <th class="compile_command" colspan="3">Compilation: <span class="code"><%= @judge_data.compilation.command %></span></th>
@@ -59,9 +59,22 @@
         <td colspan="5"><span class="code"><%= @judge_data.compilation.log %></span></td>
       </tr>
     </tbody>
-  <% end %>
+  </table>
+<% end %>
+<% if @judge_data.evaluator_compiled? && @submission.problem.evaluator && policy(@submission.problem.evaluator).inspect? %>
+<table class="results">
+  <tbody class="compilation status_<%= @judge_data.evaluator_compilation.status %>">
+    <tr>
+      <th class="compile_command" colspan="3">Evaluator Compilation: <span class="code"><%= @judge_data.evaluator_compilation.command %></span></th>
+      <th class="compile_status"><%= @judge_data.evaluator_compilation.judgement %></th>
+      <th>&nbsp;</th>
+    </tr>
+    <tr>
+      <td colspan="5"><span class="code"><%= @judge_data.evaluator_compilation.log %></span></td>
+    </tr>
+  </tbody>
 </table>
-&nbsp;
+<% end %>
 <table class="results">
   <% if !@judge_data.compiled? || @judge_data.compilation.status == :success %>
     <tbody class="headings">
@@ -152,8 +165,6 @@
     </tr>
   </tbody>
 </table>
-<br>
-<br>
 <p>
 <b>Source:</b>
 <%= predisplay(@submission.source || "", language: @submission.language.lexer) %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -62,18 +62,18 @@
   </table>
 <% end %>
 <% if @judge_data.evaluator_compiled? && @submission.problem.evaluator && policy(@submission.problem.evaluator).inspect? %>
-<table class="results">
-  <tbody class="compilation status_<%= @judge_data.evaluator_compilation.status %>">
-    <tr>
-      <th class="compile_command" colspan="3">Evaluator Compilation: <span class="code"><%= @judge_data.evaluator_compilation.command %></span></th>
-      <th class="compile_status"><%= @judge_data.evaluator_compilation.judgement %></th>
-      <th>&nbsp;</th>
-    </tr>
-    <tr>
-      <td colspan="5"><span class="code"><%= @judge_data.evaluator_compilation.log %></span></td>
-    </tr>
-  </tbody>
-</table>
+  <table class="results">
+    <tbody class="compilation status_<%= @judge_data.evaluator_compilation.status %>">
+      <tr>
+        <th class="compile_command" colspan="3">Evaluator Compilation: <span class="code"><%= @judge_data.evaluator_compilation.command %></span></th>
+        <th class="compile_status"><%= @judge_data.evaluator_compilation.judgement %></th>
+        <th>&nbsp;</th>
+      </tr>
+      <tr>
+        <td colspan="5"><span class="code"><%= @judge_data.evaluator_compilation.log %></span></td>
+      </tr>
+    </tbody>
+  </table>
 <% end %>
 <table class="results">
   <% if !@judge_data.compiled? || @judge_data.compilation.status == :success %>

--- a/app/workers/judge_submission_worker.rb
+++ b/app/workers/judge_submission_worker.rb
@@ -96,7 +96,6 @@ class JudgeSubmissionWorker < ApplicationWorker
         end
       end
 
-
       result['test_cases'] = {}
       result['test_sets'] = {}
 

--- a/app/workers/judge_submission_worker.rb
+++ b/app/workers/judge_submission_worker.rb
@@ -87,7 +87,7 @@ class JudgeSubmissionWorker < ApplicationWorker
 
         if problem.evaluator.language&.compiled
           evaluator_compilation = compile!(problem.evaluator.source, problem.evaluator.language, EvalFileName) # possible caching
-          raise evaluator_compilation['log'] if evaluator_compilation['stat'] != 0 # error
+          return result.merge!('evaluator_compile' => evaluator_compilation, 'status' => 2) if evaluator_compilation['stat'] != 0 # error
         else
           File.open(File.expand_path(EvalFileName, tmpdir),"w") do |file|
             file.chmod(0700)

--- a/db/migrate/20230225054132_add_language_id_to_evaluators.rb
+++ b/db/migrate/20230225054132_add_language_id_to_evaluators.rb
@@ -1,0 +1,5 @@
+class AddLanguageIdToEvaluators < ActiveRecord::Migration
+  def change
+    add_column :evaluators, :language_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200418113601) do
+ActiveRecord::Schema.define(version: 20230225054132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 20200418113601) do
     t.integer  "owner_id",                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "language_id"
   end
 
   create_table "file_attachments", force: :cascade do |t|


### PR DESCRIPTION
This adds an optional language field to the Evaluator class. All existing/new evaluators will default to having no language, which maintains the existing functionality (script is executed as-is).

Note that C++ evaluators were already "supported" through [cint.rb](https://github.com/NZOI/nztrain/blob/8ffcd6a82ccef82d078df33863d4d6b41e1054a3/script/install/cint.rb), but that is much slower as it requires the evaluator to be recompiled on every test case. That functionality can be considered deprecated and removed later, after fixing existing evaluators.

Also note that for evaluators with no language, Pygments will attempt to automatically detect the language based on the code (see [here](https://github.com/pygments/pygments.rb/blob/7ef665b4a1247d367f5ba7a018bc0d2baf183852/lib/pygments/mentos.py#L93)).