### PR TITLE
Pin isolate to 1.10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           SCHEDULE_BACKUPS: 0
           ISOLATE_ROOT: /
           ISOLATE_CGROUPS: false
-          ISOLATE_BRANCH: master
+          ISOLATE_BRANCH: v1.10.1
 
       - name: Back up db/schema.rb # it will be overwritten when install.bash runs migrate.bash; back up the original so we can check if it's up to date
         run: cp db/schema.rb db/schema.rb.git

--- a/script/install/config.bash
+++ b/script/install/config.bash
@@ -203,7 +203,7 @@ declare -p ISOLATE_CGROUPS &> /dev/null || while [ -z "$ISOLATE_CGROUPS" ] ; do
   else ISOLATE_CGROUPS=false; fi
 done
 
-declare -p ISOLATE_BRANCH &> /dev/null || ISOLATE_BRANCH=master # no prompt
+declare -p ISOLATE_BRANCH &> /dev/null || ISOLATE_BRANCH=v1.10.1 # no prompt
 
 
 shopt -u nocasematch;

--- a/script/install/isolate.bash
+++ b/script/install/isolate.bash
@@ -9,7 +9,7 @@ cd $srclocation
 if [ -d "isolate" ]; then
   cd isolate
   done=true
-  git pull --force | grep -q -v 'Already up-to-date.' && done=false
+  # git pull --force | grep -q -v 'Already up-to-date.' && done=false
   if $done; then
     exit
   fi


### PR DESCRIPTION
This is the last version that supports cgroups v1; isolate 2.0 supports only cgroups v2.

Note that we're currently running Ubuntu 16.04. Will need to upgrade to at least 22.04 for cgroups v2 support.