### PR TITLE
Display an error message when submitting executable.

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -87,7 +87,7 @@ class ProblemsController < ApplicationController
       @problem = Problem.find(params[:id])
       @submission = Submission.new(submit_params) # create submission
       respond_to do |format|
-        source_is_valid = @submission.source.valid_encoding? && !@submission.source.include?("\0")
+        source_is_valid = @submission.source.nil? || @submission.source.valid_encoding? && !@submission.source.include?("\0")
         if !source_is_valid
           @submission.errors.add :source_file, "has an invalid text encoding. This was likely caused by submitting a compiled file (.exe, .out, .class, ...) instead of a source code file (.cpp, .c, .java, ...)."
           @submission.source = nil; # Prevent submission form from trying to render the source (and erroring)

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -89,7 +89,7 @@ class ProblemsController < ApplicationController
       respond_to do |format|
         source_is_valid = @submission.source.valid_encoding? && !@submission.source.include?("\0")
         if !source_is_valid
-          @submission.errors.add :source_file, "- Submission has an invalid text encoding. This was likely caused by submitting a compiled file (.exe, .out, .class, ...) instead of a source code file (.cpp, .c, .java, ...)."
+          @submission.errors.add :source_file, "has an invalid text encoding. This was likely caused by submitting a compiled file (.exe, .out, .class, ...) instead of a source code file (.cpp, .c, .java, ...)."
           @submission.source = nil; # Prevent submission form from trying to render the source (and erroring)
         end
 


### PR DESCRIPTION
This pull request should resolve #257.

It displays an error message either when a submission's source has an invalid text encoding or the source contains a null character. Either conditions would have previously caused a 500 Internal Server Error.
- Having an invalid text encoding caused verification to throw an error when it tried checking if the source is blank (String#blank raises an exception when called on a string with an invalid encoding). This means that this needs to be checked before running any verification.
- If the source was valid UTF-8 but contained a null character, an error would be raised when trying to save the record because PostgreSQL does not support having null characters in strings.