### PR TITLE
Change mailer templates to be less similar to the defaults

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,8 @@
-<p>Welcome <%= @email %>!</p>
+<p>Hello <%= @resource.name %>,</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>Welcome to NZOI Training! You have signed up for an account with the username: <%= @resource.username %></p>
+<p>Before you can participate, you'll need to confirm your email address through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token) %></p>
+<p><%= link_to nil, confirmation_url(@resource, :confirmation_token => @token) %></p>
+
+<p>If you didn't request to sign up, you can ignore this email.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,11 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>Hello <%= @resource.name %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>We've received a request to reset the password for your account with username: <%= @resource.username %></p>
+<p>To reset your password, click the link below:</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token) %></p>
+<p><%= link_to nil, edit_password_url(@resource, :reset_password_token => @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>If you did not make this request, you can safely ignore this email.</p>
+<p>Your password won't be changed unless you access the link above and set a new one.</p>
+
+<p>NZOI Training</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,9 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>Hello <%= @resource.name %>!</p>
 
 <p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
 
-<p>Click the link below to unlock your account:</p>
+<p>To unlock your account, click the link below:</p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token) %></p>
+<p><%= link_to nil, unlock_url(@resource, :unlock_token => @token) %></p>
+
+<p>NZOI Training</p>

--- a/spec/controllers/accounts/passwords_controller_spec.rb
+++ b/spec/controllers/accounts/passwords_controller_spec.rb
@@ -16,7 +16,7 @@ describe Accounts::PasswordsController do
     expect(mail = ActionMailer::Base.deliveries.last).to_not be_nil
 
     host = ActionMailer::Base.default_url_options[:host]
-    expect(mail).to have_link('Change my password')
+    expect(mail).to have_link('reset_password_token')
   end
 
   context "using password reset token" do

--- a/spec/controllers/accounts/registrations_controller_spec.rb
+++ b/spec/controllers/accounts/registrations_controller_spec.rb
@@ -19,7 +19,7 @@ describe Accounts::RegistrationsController do
     # check email confirmation email sent
     expect(mail = ActionMailer::Base.deliveries.last).not_to be_nil
     expect(mail.to).to eq(["signup@nztrain.com"]) # email sent to right place
-    expect(mail).to have_link('Confirm') # email includes confirmation link
+    expect(mail).to have_link('confirmation') # email includes confirmation link
   end
 
   context 'when signed in' do

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -14,11 +14,11 @@ feature 'registration' do
     end
     mail = open_email('registration@integration.spec')
     expect(mail.to).to eq(['registration@integration.spec'])
-    expect(mail).to have_link("Confirm")
+    expect(mail).to have_link("confirmation")
 
     @user = User.find_by_username('registration_username')
     expect(@user.confirmed?).to be false
-    mail.click_link("Confirm")
+    mail.click_link("confirmation")
     visit "/accounts/confirmation?confirmation_token=#{@user.confirmation_token}"
     expect(@user.reload.confirmed?).to be true # make sure new user account is confirmed
 


### PR DESCRIPTION
The default templates from Devise were sometimes being flagged as spam by Gmail, due to being "similar to messages that were identified as spam in the past".

Possibly fixes #270.