### PR TITLE
Allow From, Reply-To addresses to be overridden in settings table

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,6 +1,4 @@
 class AdminMailer < ActionMailer::Base
-  default :from => "nztrain@gmail.com"
-
   def custom_email(admin,user,subject,msgbody)
     @user = user
     @msgbody = msgbody

--- a/app/views/user/admin_email.html.erb
+++ b/app/views/user/admin_email.html.erb
@@ -13,7 +13,7 @@
   </div>
   <p>
     <%= current_user.name %><br />
-    Admin of nztrain.com
+    Admin of NZOI Training
   </p>
 
   <div class="actions">

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,7 @@ module NZTrain
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true
     config.action_mailer.default :charset => "utf-8"
+    config.action_mailer.default :from => "nztrain@gmail.com"
 
     ActionMailer::Base.smtp_settings = {
       :address => "smtp.gmail.com",

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,7 @@ module NZTrain
       :address => "smtp.gmail.com",
       :port => 587,
       :authentication => :plain,
-      :domain => 'nztrain.com',
+      :domain => 'nzoi.org.nz',
       :user_name => 'nztrain@gmail.com', # username and password set with higher priority in settings table
       :password => 'training site',
       :enable_starttls_auto => true

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -3,5 +3,7 @@
 if ActiveRecord::Base.connection.table_exists?(Setting.table_name)
   ActionMailer::Base.smtp_settings[:user_name] = Setting.find_by_key("system/mailer/username").value if Setting.find_by_key("system/mailer/username")
   ActionMailer::Base.smtp_settings[:password] = Setting.find_by_key("system/mailer/password").value if Setting.find_by_key("system/mailer/password")
+  ActionMailer::Base.default :from => Setting.find_by_key("system/mailer/from").value if Setting.find_by_key("system/mailer/from")
+  ActionMailer::Base.default :reply_to => Setting.find_by_key("system/mailer/reply_to").value if Setting.find_by_key("system/mailer/reply_to")
 end
 


### PR DESCRIPTION
I've changed the website to send emails using train@nzoi.org.nz, but this currently causes emails to be sent with incorrect headers:

```
X-Google-Original-From: nztrain@gmail.com
Reply-To: nztrain@gmail.com
```

This would also allow setting the sender's display name, e.g. `NZOI Training <train@nzoi.org.nz>`; currently Gmail just shows the sender as "train" or "nztrain".