### PR TITLE
Set "from" email address using settings table instead of hard-coding

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,6 +1,4 @@
 class AdminMailer < ActionMailer::Base
-  default :from => "nztrain@gmail.com"
-
   def custom_email(admin,user,subject,msgbody)
     @user = user
     @msgbody = msgbody

--- a/app/views/user/admin_email.html.erb
+++ b/app/views/user/admin_email.html.erb
@@ -13,7 +13,7 @@
   </div>
   <p>
     <%= current_user.name %><br />
-    Admin of nztrain.com
+    Admin of NZOI Training
   </p>
 
   <div class="actions">

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,7 +52,7 @@ module NZTrain
       :address => "smtp.gmail.com",
       :port => 587,
       :authentication => :plain,
-      :domain => 'nztrain.com',
+      :domain => 'nzoi.org.nz',
       :user_name => 'nztrain@gmail.com', # username and password set with higher priority in settings table
       :password => 'training site',
       :enable_starttls_auto => true

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ module NZTrain
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true
-    config.action_mailer.default :charset => "utf-8"
+    config.action_mailer.default_options = { from: "nztrain@gmail.com" }
 
     ActionMailer::Base.smtp_settings = {
       :address => "smtp.gmail.com",

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,7 @@ require File.expand_path('../boot', __FILE__)
 require 'rubygems'
 require 'rails/all'
 
-if defined?(Bundler)  
+if defined?(Bundler)
   # Require the gems listed in Gemfile, including any gems
   # you've limited to :test, :development, or :production.
   Bundler.require(:default, Rails.env)
@@ -53,8 +53,8 @@ module NZTrain
       :port => 587,
       :authentication => :plain,
       :domain => 'nzoi.org.nz',
-      :user_name => 'nztrain@gmail.com', # username and password set with higher priority in settings table
-      :password => 'training site',
+      #:user_name => ..., # set in config/initializers/mailer.rb
+      #:password => ...,  # set in config/initializers/mailer.rb
       :enable_starttls_auto => true
     }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,6 @@ module NZTrain
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true
-    config.action_mailer.default_options = { from: "nztrain@gmail.com" }
 
     ActionMailer::Base.smtp_settings = {
       :address => "smtp.gmail.com",

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,6 +25,8 @@ NZTrain::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_options = { from: "train@example.com" }
+
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "nztrain@gmail.com"
+  #config.mailer_sender = ...
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,7 +1,7 @@
-# use db stored username and password for email if present
+# use db stored username and password for email
 
 if ActiveRecord::Base.connection.table_exists?(Setting.table_name)
-  ActionMailer::Base.smtp_settings[:user_name] = Setting.find_by_key("system/mailer/username").value if Setting.find_by_key("system/mailer/username")
-  ActionMailer::Base.smtp_settings[:password] = Setting.find_by_key("system/mailer/password").value if Setting.find_by_key("system/mailer/password")
+  ActionMailer::Base.smtp_settings[:user_name] = Setting.find_by_key("system/mailer/username")&.value
+  ActionMailer::Base.smtp_settings[:password] = Setting.find_by_key("system/mailer/password")&.value
 end
 

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,7 +1,8 @@
-# use db stored username and password for email
+# use db-stored email address and password for sending email
 
 if ActiveRecord::Base.connection.table_exists?(Setting.table_name)
   ActionMailer::Base.smtp_settings[:user_name] = Setting.find_by_key("system/mailer/username")&.value
   ActionMailer::Base.smtp_settings[:password] = Setting.find_by_key("system/mailer/password")&.value
+  ActionMailer::Base.default from: Setting.find_by_key("system/mailer/username").value if Setting.find_by_key("system/mailer/username")&.value.present?
 end
 

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,8 +1,8 @@
 # use db-stored email address and password for sending email
 
 if ActiveRecord::Base.connection.table_exists?(Setting.table_name)
-  ActionMailer::Base.smtp_settings[:user_name] = Setting.find_by_key("system/mailer/username")&.value
+  ActionMailer::Base.smtp_settings[:user_name] = Setting.find_by_key("system/mailer/email")&.value
   ActionMailer::Base.smtp_settings[:password] = Setting.find_by_key("system/mailer/password")&.value
-  ActionMailer::Base.default from: Setting.find_by_key("system/mailer/username").value if Setting.find_by_key("system/mailer/username")&.value.present?
+  ActionMailer::Base.default from: Setting.find_by_key("system/mailer/email").value if Setting.find_by_key("system/mailer/email")&.value.present?
 end
 

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,8 +1,17 @@
 # use db-stored email address and password for sending email
 
+def email_address_with_name(address, name)
+  # can switch to ActionMailer::Base.email_address_with_name() once we upgrade to Rails 6
+  Mail::Address.new.tap do |builder|
+    builder.address = address
+    builder.display_name = name.presence
+  end.to_s
+end
+
 if ActiveRecord::Base.connection.table_exists?(Setting.table_name)
-  ActionMailer::Base.smtp_settings[:user_name] = Setting.find_by_key("system/mailer/email")&.value
+  email_setting = Setting.find_by_key("system/mailer/email")
+  ActionMailer::Base.smtp_settings[:user_name] = email_setting&.value
   ActionMailer::Base.smtp_settings[:password] = Setting.find_by_key("system/mailer/password")&.value
-  ActionMailer::Base.default from: Setting.find_by_key("system/mailer/email").value if Setting.find_by_key("system/mailer/email")&.value.present?
+  ActionMailer::Base.default from: email_address_with_name(email_setting.value, "NZOI Training") if email_setting&.value.present?
 end
 

--- a/db/migrate/20120805061859_system_mailer_settings.rb
+++ b/db/migrate/20120805061859_system_mailer_settings.rb
@@ -1,9 +1,0 @@
-class SystemMailerSettings < ActiveRecord::Migration
-  def up
-    Setting.find_or_create_by!(key: "system/mailer/username")
-    Setting.find_or_create_by!(key: "system/mailer/password")
-  end
-
-  def down
-  end
-end

--- a/db/migrate/20120805061859_system_mailer_settings.rb
+++ b/db/migrate/20120805061859_system_mailer_settings.rb
@@ -1,7 +1,7 @@
 class SystemMailerSettings < ActiveRecord::Migration
   def up
-    Setting.find_or_create_by!(key: "system/mailer/username", value: "nztrain@gmail.com")
-    Setting.find_or_create_by!(key: "system/mailer/password", value: "training site")
+    Setting.find_or_create_by!(key: "system/mailer/username")
+    Setting.find_or_create_by!(key: "system/mailer/password")
   end
 
   def down

--- a/db/migrate/20250318053450_rename_setting_mailer_username_to_email.rb
+++ b/db/migrate/20250318053450_rename_setting_mailer_username_to_email.rb
@@ -1,0 +1,9 @@
+class RenameSettingMailerUsernameToEmail < ActiveRecord::Migration
+  def up
+    execute "UPDATE settings SET key = 'system/mailer/email' WHERE key = 'system/mailer/username'"
+  end
+
+  def down
+    execute "UPDATE settings SET key = 'system/mailer/username' WHERE key = 'system/mailer/email'"
+  end
+end

--- a/db/migrate/20250318053450_rename_setting_mailer_username_to_email.rb
+++ b/db/migrate/20250318053450_rename_setting_mailer_username_to_email.rb
@@ -1,4 +1,6 @@
 class RenameSettingMailerUsernameToEmail < ActiveRecord::Migration
+  # this migration can be deleted after deploying
+
   def up
     execute "UPDATE settings SET key = 'system/mailer/email' WHERE key = 'system/mailer/username'"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20230225054132) do
+ActiveRecord::Schema.define(version: 20250318053450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ if rootuser && rootuser.username == "root"
   superadmin.users.push(rootuser) unless superadmin.users.include?(rootuser);
 end
 
-["recaptcha/public_key","recaptcha/private_key"].each do |setting|
+["system/mailer/email","system/mailer/password","recaptcha/public_key","recaptcha/private_key"].each do |setting|
   Setting.find_or_create_by(key: setting)
 end
 

--- a/lib/development_mail_interceptor.rb
+++ b/lib/development_mail_interceptor.rb
@@ -1,7 +1,7 @@
 class DevelopmentMailInterceptor
   def self.delivering_email(message)
     message.subject = "[Development] #{message.to} #{message.subject}"
-    message.to = "nztrain@gmail.com"
+    message.to = message.from
   end
 end
 


### PR DESCRIPTION
Second version of #272.

This PR renames the setting system/mailer/username to system/mailer/email and uses that for both SMTP authentication and as "from" email address (previously it was used only for SMTP authentication, and the "from" address was hard-coded to "nztrain<span>@</span>gmail.com").

It also sets the sender's display name to "NZOI Training" and cleans up a couple of things.