### PR TITLE
Change mailer links to use https

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module NZTrain
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
-    config.action_mailer.default_url_options = { :host => 'train.nzoi.org.nz' }
+    config.action_mailer.default_url_options = { :host => 'train.nzoi.org.nz', :protocol => 'https' }
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true

--- a/spec/controllers/accounts/passwords_controller_spec.rb
+++ b/spec/controllers/accounts/passwords_controller_spec.rb
@@ -30,7 +30,7 @@ describe Accounts::PasswordsController do
       User.send_reset_password_instructions :email => @resetuser.email
       @resetuser.reload
       expect(mail = ActionMailer::Base.deliveries.last).to_not be_nil
-      expect(mail.body.encoded =~ %r{<a href=\"http://[[:alnum:]\.\:\/]+/password/edit\?reset_password_token=([^"]+)">}).to_not be_nil
+      expect(mail.body.encoded =~ %r{<a href=\"https://[[:alnum:]\.\:\/]+/password/edit\?reset_password_token=([^"]+)">}).to_not be_nil
       @reset_token = $1
     end
 

--- a/spec/controllers/accounts/registrations_controller_spec.rb
+++ b/spec/controllers/accounts/registrations_controller_spec.rb
@@ -64,7 +64,7 @@ describe Accounts::RegistrationsController do
 
       expect(mail = ActionMailer::Base.deliveries.last).to_not be_nil
       expect(mail.to).to eq ["unconfirmed@nztrain.com"] # email sent to right place
-      expect(mail.body.encoded =~ %r{<a href=\"http://[[:alnum:]\.\:\/]+\?confirmation_token=([^"]+)">}).to_not be_nil
+      expect(mail.body.encoded =~ %r{<a href=\"https://[[:alnum:]\.\:\/]+\?confirmation_token=([^"]+)">}).to_not be_nil
     end
   end
 end


### PR DESCRIPTION
This happens automatically with `config.force_ssl = true`, but [only from Rails 5](https://www.github.com/rails/rails/pull/17388).