### PR TITLE
Explicitly set `limit: 255` on string columns in migrations

### DIFF
--- a/db/migrate/20110819224757_devise_create_users.rb
+++ b/db/migrate/20110819224757_devise_create_users.rb
@@ -2,8 +2,8 @@ class DeviseCreateUsers < ActiveRecord::Migration
   def self.up
     create_table(:users) do |t|
       ## Database authenticatable
-      t.string :email,              :null => false, :default => ""
-      t.string :encrypted_password, :null => false, :default => ""
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable
       t.string   :reset_password_token
@@ -13,7 +13,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
       t.datetime :remember_created_at
 
       ## Trackable
-      t.integer  :sign_in_count, :default => 0
+      t.integer  :sign_in_count, default: 0
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
       t.string   :current_sign_in_ip
@@ -29,22 +29,22 @@ class DeviseCreateUsers < ActiveRecord::Migration
       # t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
-      # t.integer  :failed_attempts, :default => 0 # Only if lock strategy is :failed_attempts
+      # t.integer  :failed_attempts, default: 0 # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
 
       # Token authenticatable
       # t.string :authentication_token
 
-      t.boolean :is_admin, :default => false
+      t.boolean :is_admin, default: false
       t.timestamps null: true
     end
 
-    add_index :users, :email,                :unique => true
-    add_index :users, :reset_password_token, :unique => true
-    # add_index :users, :confirmation_token,   :unique => true
-    # add_index :users, :unlock_token,         :unique => true
-    # add_index :users, :authentication_token, :unique => true
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+    # add_index :users, :authentication_token, unique: true
   end
 
   def self.down

--- a/db/migrate/20110819224757_devise_create_users.rb
+++ b/db/migrate/20110819224757_devise_create_users.rb
@@ -2,11 +2,11 @@ class DeviseCreateUsers < ActiveRecord::Migration
   def self.up
     create_table(:users) do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              limit: 255, null: false, default: ""
+      t.string :encrypted_password, limit: 255, null: false, default: ""
 
       ## Recoverable
-      t.string   :reset_password_token
+      t.string   :reset_password_token, limit: 255
       t.datetime :reset_password_sent_at
 
       ## Rememberable
@@ -16,14 +16,14 @@ class DeviseCreateUsers < ActiveRecord::Migration
       t.integer  :sign_in_count, default: 0
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
-      t.string   :current_sign_in_ip
-      t.string   :last_sign_in_ip
+      t.string   :current_sign_in_ip, limit: 255
+      t.string   :last_sign_in_ip, limit: 255
 
       ## Encryptable
-      # t.string :password_salt
+      # t.string :password_salt, limit: 255
 
       ## Confirmable
-      # t.string   :confirmation_token
+      # t.string   :confirmation_token, limit: 255
       # t.datetime :confirmed_at
       # t.datetime :confirmation_sent_at
       # t.string   :unconfirmed_email # Only if using reconfirmable
@@ -34,7 +34,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
       # t.datetime :locked_at
 
       # Token authenticatable
-      # t.string :authentication_token
+      # t.string :authentication_token, limit: 255
 
       t.boolean :is_admin, default: false
       t.timestamps null: true

--- a/db/migrate/20110820005833_create_test_cases.rb
+++ b/db/migrate/20110820005833_create_test_cases.rb
@@ -4,7 +4,7 @@ class CreateTestCases < ActiveRecord::Migration
       t.text :input
       t.text :output
       t.integer :points
-      t.string :description
+      t.string :description, limit: 255
       t.integer :problem_id
 
       t.timestamps null: true

--- a/db/migrate/20110820010205_create_problems.rb
+++ b/db/migrate/20110820010205_create_problems.rb
@@ -1,10 +1,10 @@
 class CreateProblems < ActiveRecord::Migration
   def self.up
     create_table :problems do |t|
-      t.string :title
+      t.string :title, limit: 255
       t.text :statement
-      t.string :input
-      t.string :output
+      t.string :input, limit: 255
+      t.string :output, limit: 255
       t.integer :memory_limit
       t.decimal :time_limit
       t.integer :user_id

--- a/db/migrate/20110820013719_create_submissions.rb
+++ b/db/migrate/20110820013719_create_submissions.rb
@@ -2,7 +2,7 @@ class CreateSubmissions < ActiveRecord::Migration
   def self.up
     create_table :submissions do |t|
       t.text :source
-      t.string :language
+      t.string :language, limit: 255
       t.integer :score
       t.integer :user_id
       t.integer :problem_id

--- a/db/migrate/20110904033742_create_contests.rb
+++ b/db/migrate/20110904033742_create_contests.rb
@@ -1,7 +1,7 @@
 class CreateContests < ActiveRecord::Migration
   def self.up
     create_table :contests do |t|
-      t.string :title
+      t.string :title, limit: 255
       t.datetime :start_time
       t.datetime :end_time
       t.decimal :duration

--- a/db/migrate/20110904045150_create_contests_problems_table.rb
+++ b/db/migrate/20110904045150_create_contests_problems_table.rb
@@ -1,6 +1,6 @@
 class CreateContestsProblemsTable < ActiveRecord::Migration
   def self.up
-    create_table :contests_problems, :id => false do |t|
+    create_table :contests_problems, id: false do |t|
       t.integer :contest_id
       t.integer :problem_id
     end

--- a/db/migrate/20110924030742_create_groups.rb
+++ b/db/migrate/20110924030742_create_groups.rb
@@ -1,7 +1,7 @@
 class CreateGroups < ActiveRecord::Migration
   def self.up
     create_table :groups do |t|
-      t.string :name
+      t.string :name, limit: 255
 
       t.timestamps null: true
     end

--- a/db/migrate/20110924035337_create_group_user_table.rb
+++ b/db/migrate/20110924035337_create_group_user_table.rb
@@ -1,6 +1,6 @@
 class CreateGroupUserTable < ActiveRecord::Migration
   def self.up
-    create_table :groups_users, :id => false do |t|
+    create_table :groups_users, id: false do |t|
       t.integer :group_id
       t.integer :user_id
     end

--- a/db/migrate/20110925021620_create_group_problem_table.rb
+++ b/db/migrate/20110925021620_create_group_problem_table.rb
@@ -1,6 +1,6 @@
 class CreateGroupProblemTable < ActiveRecord::Migration
   def self.up
-    create_table :groups_problems, :id => false do |t|
+    create_table :groups_problems, id: false do |t|
       t.integer :group_id
       t.integer :problem_id
     end

--- a/db/migrate/20111002021523_create_contest_group_table.rb
+++ b/db/migrate/20111002021523_create_contest_group_table.rb
@@ -1,6 +1,6 @@
 class CreateContestGroupTable < ActiveRecord::Migration
   def self.up
-    create_table :contests_groups, :id => false do |t|
+    create_table :contests_groups, id: false do |t|
       t.integer :contest_id
       t.integer :group_id
     end

--- a/db/migrate/20111206102437_add_brownie_points_to_users.rb
+++ b/db/migrate/20111206102437_add_brownie_points_to_users.rb
@@ -1,6 +1,6 @@
 class AddBrowniePointsToUsers < ActiveRecord::Migration
   def self.up
-    add_column :users, :brownie_points, :integer, :default => 0
+    add_column :users, :brownie_points, :integer, default: 0
   end
 
   def self.down

--- a/db/migrate/20120111090946_add_name_to_user.rb
+++ b/db/migrate/20120111090946_add_name_to_user.rb
@@ -1,6 +1,6 @@
 class AddNameToUser < ActiveRecord::Migration
   def self.up
-    add_column :users, :name, :string
+    add_column :users, :name, :string, limit: 255
   end
 
   def self.down

--- a/db/migrate/20120117133515_add_indexes_id_fields.rb
+++ b/db/migrate/20120117133515_add_indexes_id_fields.rb
@@ -8,7 +8,7 @@ class AddIndexesIdFields < ActiveRecord::Migration
   #   - getting the users that belong to a group
   #   - getting the test cases for a problem
   def self.up
-    add_index(:contest_relations, [:contest_id, :user_id], :unique => true)
+    add_index(:contest_relations, [:contest_id, :user_id], unique: true)
     add_index(:contest_relations, [:user_id, :started_at])
 
     add_index(:submissions, [:user_id, :problem_id])

--- a/db/migrate/20120119025544_create_problem_sets.rb
+++ b/db/migrate/20120119025544_create_problem_sets.rb
@@ -1,7 +1,7 @@
 class CreateProblemSets < ActiveRecord::Migration
   def self.up
     create_table :problem_sets do |t|
-      t.string :title
+      t.string :title, limit: 255
       t.integer :user_id
       t.timestamps null: true
     end

--- a/db/migrate/20120119025544_create_problem_sets.rb
+++ b/db/migrate/20120119025544_create_problem_sets.rb
@@ -6,11 +6,11 @@ class CreateProblemSets < ActiveRecord::Migration
       t.timestamps null: true
     end
     # add association tables
-    create_table :problem_sets_problems, :id => false do |t|
+    create_table :problem_sets_problems, id: false do |t|
       t.integer :problem_set_id
       t.integer :problem_id
     end
-    create_table :groups_problem_sets, :id => false do |t|
+    create_table :groups_problem_sets, id: false do |t|
       t.integer :group_id
       t.integer :problem_set_id
     end

--- a/db/migrate/20120119081526_remove_problems_contests_groups.rb
+++ b/db/migrate/20120119081526_remove_problems_contests_groups.rb
@@ -5,11 +5,11 @@ class RemoveProblemsContestsGroups < ActiveRecord::Migration
   end
 
   def self.down
-    create_table :groups_problems, :id => false do |t|
+    create_table :groups_problems, id: false do |t|
       t.integer :group_id
       t.integer :problem_id
     end
-    create_table :contests_problems, :id => false do |t|
+    create_table :contests_problems, id: false do |t|
       t.integer :contest_id
       t.integer :problem_id
     end

--- a/db/migrate/20120122061329_create_roles.rb
+++ b/db/migrate/20120122061329_create_roles.rb
@@ -3,7 +3,7 @@ class CreateRoles < ActiveRecord::Migration
     create_table :roles do |t|
       t.string :name
     end
-    create_table :roles_users, :id => false do |t|
+    create_table :roles_users, id: false do |t|
       t.integer :role_id
       t.integer :user_id
     end

--- a/db/migrate/20120122061329_create_roles.rb
+++ b/db/migrate/20120122061329_create_roles.rb
@@ -1,7 +1,7 @@
 class CreateRoles < ActiveRecord::Migration
   def self.up
     create_table :roles do |t|
-      t.string :name
+      t.string :name, limit: 255
     end
     create_table :roles_users, id: false do |t|
       t.integer :role_id

--- a/db/migrate/20120127063021_add_username_to_users.rb
+++ b/db/migrate/20120127063021_add_username_to_users.rb
@@ -1,8 +1,8 @@
 class AddUsernameToUsers < ActiveRecord::Migration
   def self.up
     add_column :users, :username, :string
-    add_column :users, :can_change_username, :boolean, :default => true, :null => false
-    change_column :users, :can_change_username, :boolean, :default => false, :null => false
+    add_column :users, :can_change_username, :boolean, default: true, null: false
+    change_column :users, :can_change_username, :boolean, default: false, null: false
     User.all.each do |user|
       user.update_attribute(:username, user.email.split('@')[0])
     end
@@ -15,7 +15,7 @@ class AddUsernameToUsers < ActiveRecord::Migration
     users.each do |user|
       user.update_attribute(:username, user.email.split('@')[0] + '.' + user.email.split('@')[1].split('.')[0]);
     end
-    change_column :users, :username, :string, :null => false, :unique => true
+    change_column :users, :username, :string, null: false, unique: true
     case ActiveRecord::Base.connection.adapter_name
     when 'SQLite'
       execute "CREATE INDEX index_users_on_username ON users (username collate nocase)"

--- a/db/migrate/20120127063021_add_username_to_users.rb
+++ b/db/migrate/20120127063021_add_username_to_users.rb
@@ -1,6 +1,6 @@
 class AddUsernameToUsers < ActiveRecord::Migration
   def self.up
-    add_column :users, :username, :string
+    add_column :users, :username, :string, limit: 255
     add_column :users, :can_change_username, :boolean, default: true, null: false
     change_column :users, :can_change_username, :boolean, default: false, null: false
     User.all.each do |user|
@@ -15,7 +15,7 @@ class AddUsernameToUsers < ActiveRecord::Migration
     users.each do |user|
       user.update_attribute(:username, user.email.split('@')[0] + '.' + user.email.split('@')[1].split('.')[0]);
     end
-    change_column :users, :username, :string, null: false, unique: true
+    change_column :users, :username, :string, limit: 255, null: false, unique: true
     case ActiveRecord::Base.connection.adapter_name
     when 'SQLite'
       execute "CREATE INDEX index_users_on_username ON users (username collate nocase)"

--- a/db/migrate/20120128000525_create_settings.rb
+++ b/db/migrate/20120128000525_create_settings.rb
@@ -1,8 +1,8 @@
 class CreateSettings < ActiveRecord::Migration
   def self.up
     create_table :settings do |t|
-      t.string :key
-      t.string :value
+      t.string :key, limit: 255
+      t.string :value, limit: 255
     end
     add_index :settings, :key, unique: true
   end

--- a/db/migrate/20120128000525_create_settings.rb
+++ b/db/migrate/20120128000525_create_settings.rb
@@ -4,7 +4,7 @@ class CreateSettings < ActiveRecord::Migration
       t.string :key
       t.string :value
     end
-    add_index :settings, :key, :unique => true
+    add_index :settings, :key, unique: true
   end
 
   def self.down

--- a/db/migrate/20120128235138_create_evaluators.rb
+++ b/db/migrate/20120128235138_create_evaluators.rb
@@ -1,10 +1,10 @@
 class CreateEvaluators < ActiveRecord::Migration
   def self.up
     create_table :evaluators do |t|
-      t.string :name, :unique => true, :null => false
-      t.text :description, :null => false, :default => ""
-      t.text :source, :null => false, :default => ""
-      t.integer :user_id, :null => false
+      t.string :name, unique: true, null: false
+      t.text :description, null: false, default: ""
+      t.text :source, null: false, default: ""
+      t.integer :user_id, null: false
 
       t.timestamps null: true
     end

--- a/db/migrate/20120128235138_create_evaluators.rb
+++ b/db/migrate/20120128235138_create_evaluators.rb
@@ -1,7 +1,7 @@
 class CreateEvaluators < ActiveRecord::Migration
   def self.up
     create_table :evaluators do |t|
-      t.string :name, unique: true, null: false
+      t.string :name, limit: 255, unique: true, null: false
       t.text :description, null: false, default: ""
       t.text :source, null: false, default: ""
       t.integer :user_id, null: false

--- a/db/migrate/20120201113029_add_sessions_table.rb
+++ b/db/migrate/20120201113029_add_sessions_table.rb
@@ -1,7 +1,7 @@
 class AddSessionsTable < ActiveRecord::Migration
   def self.up
     create_table :sessions do |t|
-      t.string :session_id, :null => false
+      t.string :session_id, null: false
       t.text :data
       t.timestamps null: true
     end

--- a/db/migrate/20120201113029_add_sessions_table.rb
+++ b/db/migrate/20120201113029_add_sessions_table.rb
@@ -1,7 +1,7 @@
 class AddSessionsTable < ActiveRecord::Migration
   def self.up
     create_table :sessions do |t|
-      t.string :session_id, null: false
+      t.string :session_id, limit: 255, null: false
       t.text :data
       t.timestamps null: true
     end

--- a/db/migrate/20120208061444_add_avatar_to_user.rb
+++ b/db/migrate/20120208061444_add_avatar_to_user.rb
@@ -1,6 +1,6 @@
 class AddAvatarToUser < ActiveRecord::Migration
   def self.up
-    add_column :users, :avatar, :string
+    add_column :users, :avatar, :string, limit: 255
   end
 
   def self.down

--- a/db/migrate/20120210235859_create_test_sets.rb
+++ b/db/migrate/20120210235859_create_test_sets.rb
@@ -3,7 +3,7 @@ class CreateTestSets < ActiveRecord::Migration
     create_table :test_sets do |t|
       t.integer :problem_id
       t.integer :points
-      t.string :name
+      t.string :name, limit: 255
 
       t.timestamps null: true
     end

--- a/db/migrate/20120805020042_add_confirmable_to_users.rb
+++ b/db/migrate/20120805020042_add_confirmable_to_users.rb
@@ -1,9 +1,9 @@
 class AddConfirmableToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmation_token, :string, limit: 255
     add_column :users, :confirmed_at,       :datetime
     add_column :users, :confirmation_sent_at , :datetime
-    add_column :users, :unconfirmed_email , :string
+    add_column :users, :unconfirmed_email , :string, limit: 255
  
     add_index  :users, :confirmation_token, unique: true
   end

--- a/db/migrate/20120805020042_add_confirmable_to_users.rb
+++ b/db/migrate/20120805020042_add_confirmable_to_users.rb
@@ -5,6 +5,6 @@ class AddConfirmableToUsers < ActiveRecord::Migration
     add_column :users, :confirmation_sent_at , :datetime
     add_column :users, :unconfirmed_email , :string
  
-    add_index  :users, :confirmation_token, :unique => true
+    add_index  :users, :confirmation_token, unique: true
   end
 end

--- a/db/migrate/20120807033035_add_end_time_to_contest_relations.rb
+++ b/db/migrate/20120807033035_add_end_time_to_contest_relations.rb
@@ -3,7 +3,7 @@ class AddEndTimeToContestRelations < ActiveRecord::Migration
     add_column :contest_relations, :finish_at, :datetime # will be updated by caching
     Contest.find_each do |contest|
       contest.contest_relations.find_each do |relation|
-        relation.finish_at = [contest.end_time,relation.started_at.advance(:hours => contest.duration)].min
+        relation.finish_at = [contest.end_time,relation.started_at.advance(hours: contest.duration)].min
         relation.save
       end
     end

--- a/db/migrate/20120807042326_create_contest_scores.rb
+++ b/db/migrate/20120807042326_create_contest_scores.rb
@@ -3,8 +3,8 @@ class CreateContestScores < ActiveRecord::Migration
     # table to cache submission score for each problem/user (of all submissions that have been created)
     # however, this score may differ from actual submission score if it gets rejudged after a contest has been sealed
     create_table :contest_scores do |t|
-      t.references :contest_relation, :null => false
-      t.references :problem, :null => false
+      t.references :contest_relation, null: false
+      t.references :problem, null: false
       t.integer :score
       t.integer :attempts
       t.integer :attempt
@@ -15,9 +15,9 @@ class CreateContestScores < ActiveRecord::Migration
     add_index :contest_scores, [:contest_relation_id,:problem_id]
 
     # columns in contest_relations to cache important data
-    add_column :contest_relations, :score, :integer, :null => false, :default => 0 # column to cache total score
-    add_column :contest_relations, :time_taken, :float, :limit => 53, :null => false, :default => 0 # column to cache time taken
-    add_index :contest_relations, [:contest_id,:score,:time_taken], :order => {:contest_id => :asc, :score => :desc, :time_taken => :asc} # index to make it easy to get scores in sorted order for a specific contest
+    add_column :contest_relations, :score, :integer, null: false, default: 0 # column to cache total score
+    add_column :contest_relations, :time_taken, :float, limit: 53, null: false, default: 0 # column to cache time taken
+    add_index :contest_relations, [:contest_id,:score,:time_taken], order: {contest_id: :asc, score: :desc, time_taken: :asc} # index to make it easy to get scores in sorted order for a specific contest
 
     # populate cache table for current contests
     Contest.find_each do |contest|

--- a/db/migrate/20120810041325_add_results_final_to_contest.rb
+++ b/db/migrate/20120810041325_add_results_final_to_contest.rb
@@ -1,6 +1,6 @@
 class AddResultsFinalToContest < ActiveRecord::Migration
   def up
-    add_column :contests, :finalized_at, :datetime, :default => nil
+    add_column :contests, :finalized_at, :datetime, default: nil
 
     Contest.find_each do |contest|
       if contest.end_time < DateTime.now

--- a/db/migrate/20130116092216_add_input_output_to_submissions.rb
+++ b/db/migrate/20130116092216_add_input_output_to_submissions.rb
@@ -1,7 +1,7 @@
 class AddInputOutputToSubmissions < ActiveRecord::Migration
   def up
-    add_column :submissions, :input, :string
-    add_column :submissions, :output, :string
+    add_column :submissions, :input, :string, limit: 255
+    add_column :submissions, :output, :string, limit: 255
 
     Submission.all.each do |sub|
       sub.input = sub.problem.input

--- a/db/migrate/20130926065258_add_visibility_and_membership_to_groups.rb
+++ b/db/migrate/20130926065258_add_visibility_and_membership_to_groups.rb
@@ -1,6 +1,6 @@
 class AddVisibilityAndMembershipToGroups < ActiveRecord::Migration
   def change
-    add_column :groups, :visibility, :integer, :null => false, :default => 0
-    add_column :groups, :membership, :integer, :null => false, :default => 0
+    add_column :groups, :visibility, :integer, null: false, default: 0
+    add_column :groups, :membership, :integer, null: false, default: 0
   end
 end

--- a/db/migrate/20130926105411_create_requests.rb
+++ b/db/migrate/20130926105411_create_requests.rb
@@ -2,9 +2,13 @@ class CreateRequests < ActiveRecord::Migration
   def change
     create_table :requests do |t|
       t.references :requester
-      t.references :subject, polymorphic: true
+      # replaces `t.references :subject, polymorphic: true` to add limit: 255
+      t.integer :subject_id
+      t.string :subject_type
       t.string :verb, null: false
-      t.references :target, null: false, polymorphic: true # :object_id is reserved
+      # replaces `t.references :target, null: false, polymorphic: true` to add limit: 255
+      t.integer :target_id, null: false
+      t.string :target_type, null: false
       t.integer :status, null: false, default: 0
       t.references :requestee
       t.datetime :expired_at, null: false, default: :infinity

--- a/db/migrate/20130926105411_create_requests.rb
+++ b/db/migrate/20130926105411_create_requests.rb
@@ -4,11 +4,11 @@ class CreateRequests < ActiveRecord::Migration
       t.references :requester
       # replaces `t.references :subject, polymorphic: true` to add limit: 255
       t.integer :subject_id
-      t.string :subject_type
-      t.string :verb, null: false
+      t.string :subject_type, limit: 255
+      t.string :verb, limit: 255, null: false
       # replaces `t.references :target, null: false, polymorphic: true` to add limit: 255
       t.integer :target_id, null: false
-      t.string :target_type, null: false
+      t.string :target_type, limit: 255, null: false
       t.integer :status, null: false, default: 0
       t.references :requestee
       t.datetime :expired_at, null: false, default: :infinity

--- a/db/migrate/20130926105411_create_requests.rb
+++ b/db/migrate/20130926105411_create_requests.rb
@@ -2,12 +2,12 @@ class CreateRequests < ActiveRecord::Migration
   def change
     create_table :requests do |t|
       t.references :requester
-      t.references :subject, :polymorphic => true
-      t.string :verb, :null => false
-      t.references :target, :null => false, :polymorphic => true # :object_id is reserved
-      t.integer :status, :null => false, :default => 0
+      t.references :subject, polymorphic: true
+      t.string :verb, null: false
+      t.references :target, null: false, polymorphic: true # :object_id is reserved
+      t.integer :status, null: false, default: 0
       t.references :requestee
-      t.datetime :expired_at, :null => false, :default => :infinity
+      t.datetime :expired_at, null: false, default: :infinity
 
       t.timestamps null: false
     end

--- a/db/migrate/20131001083843_create_file_attachments.rb
+++ b/db/migrate/20131001083843_create_file_attachments.rb
@@ -1,8 +1,8 @@
 class CreateFileAttachments < ActiveRecord::Migration
   def change
     create_table :file_attachments do |t|
-      t.string :name
-      t.string :file_attachment
+      t.string :name, limit: 255
+      t.string :file_attachment, limit: 255
       t.references :owner
 
       t.timestamps null: false

--- a/db/migrate/20131001083843_create_file_attachments.rb
+++ b/db/migrate/20131001083843_create_file_attachments.rb
@@ -2,7 +2,7 @@ class CreateFileAttachments < ActiveRecord::Migration
   def change
     create_table :file_attachments do |t|
       t.string :name
-      t.string :file_attachment, :string
+      t.string :file_attachment
       t.references :owner
 
       t.timestamps null: false

--- a/db/migrate/20131002083519_add_filepath_to_group_file_attachments.rb
+++ b/db/migrate/20131002083519_add_filepath_to_group_file_attachments.rb
@@ -1,6 +1,6 @@
 class AddFilepathToGroupFileAttachments < ActiveRecord::Migration
   def change
-    add_column :group_file_attachments, :filepath, :string
+    add_column :group_file_attachments, :filepath, :string, limit: 255
 
     add_index :group_file_attachments, [:group_id, :filepath]
     add_index :group_file_attachments, :file_attachment_id

--- a/db/migrate/20131007025034_convert_test_case_associations.rb
+++ b/db/migrate/20131007025034_convert_test_case_associations.rb
@@ -5,8 +5,8 @@ class ConvertTestCaseAssociations < ActiveRecord::Migration
     ## too slow
     #TestCase.find_each do |test_case|
     #  relation = TestCaseRelation.new(
-    #    :test_case => test_case,
-    #    :test_set => TestSet.find(test_case.test_set_id));
+    #    test_case: test_case,
+    #    test_set: TestSet.find(test_case.test_set_id));
     #    relation.save
     #end
     remove_column :test_cases, :test_set_id
@@ -19,7 +19,7 @@ class ConvertTestCaseAssociations < ActiveRecord::Migration
       sets = test_case.test_sets
       test_case.test_set_id = sets.first.id
       sets.drop(1).each do |set|
-        TestCase.create(test_case.attributes.merge(:test_set_id => set.id))
+        TestCase.create(test_case.attributes.merge(test_set_id: set.id))
       end
     end
   end

--- a/db/migrate/20131013045616_create_languages.rb
+++ b/db/migrate/20131013045616_create_languages.rb
@@ -1,8 +1,8 @@
 class CreateLanguages < ActiveRecord::Migration
   def change
     create_table :languages do |t|
-      t.string :name
-      t.string :compiler
+      t.string :name, limit: 255
+      t.string :compiler, limit: 255
       t.boolean :is_interpreted
 
       t.timestamps null: false

--- a/db/migrate/20131013050536_add_language_id_to_submission.rb
+++ b/db/migrate/20131013050536_add_language_id_to_submission.rb
@@ -16,7 +16,7 @@ class AddLanguageIdToSubmission < ActiveRecord::Migration
   end
 
   def down
-    add_column :submissions, :old_language, :string
+    add_column :submissions, :old_language, :string, limit: 255
 
     execute "UPDATE submissions SET old_language = (SELECT name FROM languages WHERE languages.id = submissions.language_id);"
 

--- a/db/migrate/20131013050536_add_language_id_to_submission.rb
+++ b/db/migrate/20131013050536_add_language_id_to_submission.rb
@@ -4,12 +4,12 @@ class AddLanguageIdToSubmission < ActiveRecord::Migration
     rename_column :submissions, :language, :old_language
 
     Submission.select(:old_language).uniq.each do |submission|
-      Language.where(:name => submission.old_language).first_or_create!
+      Language.where(name: submission.old_language).first_or_create!
     end
 
     execute "UPDATE submissions SET language_id = (SELECT id FROM languages WHERE languages.name = submissions.old_language);"
     # Check that language relations migrated successfully
-    failures = Submission.where(:language_id => nil).count
+    failures = Submission.where(language_id: nil).count
     raise "Languages in #{failures} submissions failed to migrate" if failures > 0
 
     remove_column :submissions, :old_language

--- a/db/migrate/20131112032835_change_languages.rb
+++ b/db/migrate/20131112032835_change_languages.rb
@@ -1,6 +1,6 @@
 class ChangeLanguages < ActiveRecord::Migration
   def change
     rename_column :languages, :is_interpreted, :interpreted
-    add_column :languages, :flags, :string
+    add_column :languages, :flags, :string, limit: 255
   end
 end

--- a/db/migrate/20131117055333_add_extension_to_language.rb
+++ b/db/migrate/20131117055333_add_extension_to_language.rb
@@ -1,5 +1,5 @@
 class AddExtensionToLanguage < ActiveRecord::Migration
   def change
-    add_column :languages, :extension, :string
+    add_column :languages, :extension, :string, limit: 255
   end
 end

--- a/db/migrate/20131205080753_add_job_to_submissions.rb
+++ b/db/migrate/20131205080753_add_job_to_submissions.rb
@@ -1,5 +1,5 @@
 class AddJobToSubmissions < ActiveRecord::Migration
   def change
-    add_column :submissions, :job, :string
+    add_column :submissions, :job, :string, limit: 255
   end
 end

--- a/db/migrate/20131205201359_add_type_to_test_set.rb
+++ b/db/migrate/20131205201359_add_type_to_test_set.rb
@@ -1,6 +1,6 @@
 class AddTypeToTestSet < ActiveRecord::Migration
   def up
-    add_column :test_sets, :visibility, :integer, :limit => 1, :null => false, :default => 2
+    add_column :test_sets, :visibility, :integer, limit: 1, null: false, default: 2
     add_column :test_cases, :problem_id, :integer
 
     TestCase.reset_column_information # get problem association
@@ -8,7 +8,7 @@ class AddTypeToTestSet < ActiveRecord::Migration
       p = cas.problems.pluck(:id)
       case p.size
       when 0; cas.destroy
-      when 1; TestCase.update(cas.id, :problem_id => p.first)
+      when 1; TestCase.update(cas.id, problem_id: p.first)
       else; raise "Not implemented error: test case has multiple problems - test case will need to be duplicated"
       end
     end

--- a/db/migrate/20131206074948_name_all_test_sets_and_cases.rb
+++ b/db/migrate/20131206074948_name_all_test_sets_and_cases.rb
@@ -7,8 +7,8 @@ class NameAllTestSetsAndCases < ActiveRecord::Migration
       name_uniquely(problem.test_cases)
     end
 
-    add_index :test_sets, [:problem_id, :name], :unique => true
-    add_index :test_cases, [:problem_id, :name], :unique => true
+    add_index :test_sets, [:problem_id, :name], unique: true
+    add_index :test_cases, [:problem_id, :name], unique: true
   end
 
   def down
@@ -24,7 +24,7 @@ class NameAllTestSetsAndCases < ActiveRecord::Migration
     relation.select([:id, :name]).each do |obj|
       if !names.include?(obj.name)
         i+=1 while names.include?(i.to_s)
-        klass.update(obj.id, :name => i.to_s)
+        klass.update(obj.id, name: i.to_s)
         i+=1
       end
     end

--- a/db/migrate/20131207080120_change_enumeration_on_test_sets.rb
+++ b/db/migrate/20131207080120_change_enumeration_on_test_sets.rb
@@ -1,13 +1,13 @@
 class ChangeEnumerationOnTestSets < ActiveRecord::Migration
   def up
-    change_column :test_sets, :visibility, :integer, :limit => 1, :default => 0
+    change_column :test_sets, :visibility, :integer, limit: 1, default: 0
     execute 'UPDATE test_sets SET visibility = 3 WHERE visibility = 0' # sample
     execute 'UPDATE test_sets SET visibility = 0 WHERE visibility = 2' # private
     execute 'UPDATE test_sets SET visibility = 2 WHERE visibility = 1' # prerequisite
   end
 
   def down
-    change_column :test_sets, :visibility, :integer, :limit => 1, :default => 2
+    change_column :test_sets, :visibility, :integer, limit: 1, default: 2
     execute 'UPDATE test_sets SET visibility = 1 WHERE visibility = 2' # prerequisite
     execute 'UPDATE test_sets SET visibility = 2 WHERE visibility = 0' # private
     execute 'UPDATE test_sets SET visibility = 0 WHERE visibility = 3' # sample

--- a/db/migrate/20131207091535_convert_dummy_test_sets_to_samples.rb
+++ b/db/migrate/20131207091535_convert_dummy_test_sets_to_samples.rb
@@ -2,7 +2,7 @@ class ConvertDummyTestSetsToSamples < ActiveRecord::Migration
   def up
     # mainly for the COCI problems
     TestSet.where("name LIKE '%dummy%'").find_each do |set|
-      set.update_attributes(:visibility => TestSet::VISIBILITY[:sample])
+      set.update_attributes(visibility: TestSet::VISIBILITY[:sample])
       set.problem.submissions.find_each do |submission|
         submission.rejudge
       end

--- a/db/migrate/20131208014408_add_language_group_model.rb
+++ b/db/migrate/20131208014408_add_language_group_model.rb
@@ -1,8 +1,8 @@
 class AddLanguageGroupModel < ActiveRecord::Migration
   def change
     create_table :language_groups do |t|
-      t.string :identifier
-      t.string :name
+      t.string :identifier, limit: 255
+      t.string :name, limit: 255
       t.references :current_language
       t.timestamps null: false
     end
@@ -12,8 +12,8 @@ class AddLanguageGroupModel < ActiveRecord::Migration
     add_column :languages, :compiled, :boolean
 
     rename_column :languages, :name, :identifier
-    add_column :languages, :name, :string
-    add_column :languages, :lexer, :string
+    add_column :languages, :name, :string, limit: 255
+    add_column :languages, :lexer, :string, limit: 255
     add_column :languages, :group_id, :integer
 
     add_index :languages, :identifier, unique: true

--- a/db/migrate/20131208014408_add_language_group_model.rb
+++ b/db/migrate/20131208014408_add_language_group_model.rb
@@ -7,7 +7,7 @@ class AddLanguageGroupModel < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    add_index :language_groups, :identifier, :unique => true
+    add_index :language_groups, :identifier, unique: true
 
     add_column :languages, :compiled, :boolean
 
@@ -16,6 +16,6 @@ class AddLanguageGroupModel < ActiveRecord::Migration
     add_column :languages, :lexer, :string
     add_column :languages, :group_id, :integer
 
-    add_index :languages, :identifier, :unique => true
+    add_index :languages, :identifier, unique: true
   end
 end

--- a/db/migrate/20131208015044_change_language_identifiers_to_match.rb
+++ b/db/migrate/20131208015044_change_language_identifiers_to_match.rb
@@ -5,13 +5,13 @@ class ChangeLanguageIdentifiersToMatch < ActiveRecord::Migration
 
   def up
     Language.all.each do |language|
-      language.update_attributes(:name => language.identifier, :identifier => mapping.fetch(language.identifier, language.identifier))
+      language.update_attributes(name: language.identifier, identifier: mapping.fetch(language.identifier, language.identifier))
     end
   end
 
   def down
     Language.all.each do |language|
-      language.update_attributes(:identifier => mapping.invert.fetch(language.identifier, language.identifier))
+      language.update_attributes(identifier: mapping.invert.fetch(language.identifier, language.identifier))
     end
   end
 end

--- a/db/migrate/20131208131723_rename_bad_usernames.rb
+++ b/db/migrate/20131208131723_rename_bad_usernames.rb
@@ -2,8 +2,8 @@ class RenameBadUsernames < ActiveRecord::Migration
   def up
     User.find_each do |user|
       if !user.save # bad username
-        user.update_attributes(:username => user.email.split('@')[0], :can_change_username => true) or
-        user.update_attributes(:username => user.email.gsub(/@/,'.'), :can_change_username => true)
+        user.update_attributes(username: user.email.split('@')[0], can_change_username: true) or
+        user.update_attributes(username: user.email.gsub(/@/,'.'), can_change_username: true)
       end
     end
   end

--- a/db/migrate/20131217112526_change_test_set_and_test_case_sample_and_prerequisites.rb
+++ b/db/migrate/20131217112526_change_test_set_and_test_case_sample_and_prerequisites.rb
@@ -1,14 +1,14 @@
 class ChangeTestSetAndTestCaseSampleAndPrerequisites < ActiveRecord::Migration
   def up
-    add_column :test_sets, :prerequisite, :boolean, :default => false
-    add_column :test_cases, :sample, :boolean, :default => false
+    add_column :test_sets, :prerequisite, :boolean, default: false
+    add_column :test_cases, :sample, :boolean, default: false
     execute 'UPDATE test_sets SET prerequisite = (visibility >= 2)'
     execute 'UPDATE test_cases SET sample = true WHERE test_cases.id IN (SELECT test_case_relations.test_case_id FROM test_case_relations JOIN test_sets ON test_case_relations.test_set_id = test_sets.id WHERE test_sets.visibility = 1 OR test_sets.visibility = 3)'
     remove_column :test_sets, :visibility
   end
 
   def down
-    add_column :test_sets, :visibility, :integer, :limit => 1, :null => false, :default => 0
+    add_column :test_sets, :visibility, :integer, limit: 1, null: false, default: 0
     execute 'UPDATE test_sets SET visibility = 2 WHERE prerequisite'
     # suppose all test sets could be a sample test set
     execute 'UPDATE test_sets SET visibility = visibility + 1 WHERE prerequisite'
@@ -17,9 +17,9 @@ class ChangeTestSetAndTestCaseSampleAndPrerequisites < ActiveRecord::Migration
     # test cases which are not in a sample test set will need a new test set
     Problem.all.find_each do |problem|
       # samples which do not have a sample test set
-      missed_samples = problem.test_cases.where("id NOT IN (?) AND sample", TestCaseRelation.where(:test_set_id => problem.test_sets.where("visibility = 1 OR visibility = 3")).select(:test_case_id))
+      missed_samples = problem.test_cases.where("id NOT IN (?) AND sample", TestCaseRelation.where(test_set_id: problem.test_sets.where("visibility = 1 OR visibility = 3")).select(:test_case_id))
       if missed_samples.any?
-        problem.test_sets << TestSet.new(:name => "sample test set", :points => 0, :visibility => 1, :test_case_ids => missed_samples.pluck(:id))
+        problem.test_sets << TestSet.new(name: "sample test set", points: 0, visibility: 1, test_case_ids: missed_samples.pluck(:id))
       end
     end
     remove_column :test_sets, :prerequisite

--- a/db/migrate/20131219083253_make_attachments_polymorphic.rb
+++ b/db/migrate/20131219083253_make_attachments_polymorphic.rb
@@ -2,7 +2,7 @@ class MakeAttachmentsPolymorphic < ActiveRecord::Migration
   def up
     rename_table :group_file_attachments, :filelinks
     rename_column :filelinks, :group_id, :root_id
-    add_column :filelinks, :root_type, :string
+    add_column :filelinks, :root_type, :string, limit: 255
 
     drop_table :problem_file_attachments
 

--- a/db/migrate/20131220034551_change_habtm_problem_associations.rb
+++ b/db/migrate/20131220034551_change_habtm_problem_associations.rb
@@ -64,7 +64,7 @@ class ChangeHabtmProblemAssociations < ActiveRecord::Migration
     execute 'UPDATE problem_set_problems SET problem_set_order = id*10'
 
     # give problem sets in groups custom names
-    add_column :group_problem_sets, :name, :string
+    add_column :group_problem_sets, :name, :string, limit: 255
 
     execute 'DROP INDEX IF EXISTS index_problems_on_title'
 

--- a/db/migrate/20131220034551_change_habtm_problem_associations.rb
+++ b/db/migrate/20131220034551_change_habtm_problem_associations.rb
@@ -78,7 +78,7 @@ class ChangeHabtmProblemAssociations < ActiveRecord::Migration
     rename_column :problems, :name, :title
     rename_column :problem_sets, :name, :title
 
-    add_index :problems, :title, :unique => true
+    add_index :problems, :title, unique: true
 
     remove_column :group_problem_sets, :name
     remove_column :problem_set_problems, :problem_set_order

--- a/db/migrate/20131221014009_create_user_problem_relation.rb
+++ b/db/migrate/20131221014009_create_user_problem_relation.rb
@@ -4,12 +4,12 @@ class CreateUserProblemRelation < ActiveRecord::Migration
       dir.up do
         missing_user_ids = Submission.where{ |submission| submission.user_id << User.select(:id) }.pluck(:user_id)
 
-        Submission.where(:user_id => missing_user_ids).delete_all
-        ContestRelation.where(:user_id => missing_user_ids).destroy_all
+        Submission.where(user_id: missing_user_ids).delete_all
+        ContestRelation.where(user_id: missing_user_ids).destroy_all
       end
     end
 
-    add_column :submissions, :classification, :integer, :default => 0
+    add_column :submissions, :classification, :integer, default: 0
 
     reversible do |dir|
       dir.up do
@@ -42,7 +42,7 @@ class CreateUserProblemRelation < ActiveRecord::Migration
     reversible do |dir|
       dir.up do
         Submission.select([:user_id, :problem_id]).distinct.each do |submission|
-          relation = UserProblemRelation.where(:user_id => submission[:user_id], :problem_id => submission[:problem_id]).first_or_create!
+          relation = UserProblemRelation.where(user_id: submission[:user_id], problem_id: submission[:problem_id]).first_or_create!
           relation.recalculate_and_save
           relation.first_viewed_at = relation.submissions.minimum(:created_at)
           relation.last_viewed_at = relation.submissions.maximum(:created_at)

--- a/db/migrate/20131221101354_remove_submission_classification_default.rb
+++ b/db/migrate/20131221101354_remove_submission_classification_default.rb
@@ -1,9 +1,9 @@
 class RemoveSubmissionClassificationDefault < ActiveRecord::Migration
   def up
-    change_column :submissions, :classification, :integer, :default => nil
+    change_column :submissions, :classification, :integer, default: nil
   end
 
   def down
-    change_column :submissions, :classification, :integer, :default => 0
+    change_column :submissions, :classification, :integer, default: 0
   end
 end

--- a/db/migrate/20131222110552_add_error_warnings_to_problem.rb
+++ b/db/migrate/20131222110552_add_error_warnings_to_problem.rb
@@ -4,7 +4,7 @@ class AddErrorWarningsToProblem < ActiveRecord::Migration
     add_column :problems, :test_warning_count, :integer, default: 0
 
     # used for errors and warnings
-    add_column :submissions, :test_errors, :string, array: true
-    add_column :submissions, :test_warnings, :string, array: true
+    add_column :submissions, :test_errors, :string, limit: 255, array: true
+    add_column :submissions, :test_warnings, :string, limit: 255, array: true
   end
 end

--- a/db/migrate/20131226232008_create_problem_series.rb
+++ b/db/migrate/20131226232008_create_problem_series.rb
@@ -5,8 +5,5 @@ class CreateProblemSeries < ActiveRecord::Migration
       t.string :identifier
       t.string :importer_type
     end
-
-    # unused column
-    remove_column :file_attachments, :string, :string
   end
 end

--- a/db/migrate/20131226232008_create_problem_series.rb
+++ b/db/migrate/20131226232008_create_problem_series.rb
@@ -1,9 +1,9 @@
 class CreateProblemSeries < ActiveRecord::Migration
   def change
     create_table :problem_series do |t|
-      t.string :name
-      t.string :identifier
-      t.string :importer_type
+      t.string :name, limit: 255
+      t.string :identifier, limit: 255
+      t.string :importer_type, limit: 255
     end
   end
 end

--- a/db/migrate/20140206025958_create_items_and_products.rb
+++ b/db/migrate/20140206025958_create_items_and_products.rb
@@ -1,15 +1,15 @@
 class CreateItemsAndProducts < ActiveRecord::Migration
   def change
     create_table :entities do |t|
-      t.string :name
+      t.string :name, limit: 255
       # replaces `t.references :entity, polymorphic: true` to add limit: 255
       t.integer :entity_id
-      t.string :entity_type
+      t.string :entity_type, limit: 255
     end
     create_table :organisations do |t|
     end
     create_table :products do |t|
-      t.string :name
+      t.string :name, limit: 255
       t.integer :gtin, limit: 8
     end
     create_table :items do |t|

--- a/db/migrate/20140206025958_create_items_and_products.rb
+++ b/db/migrate/20140206025958_create_items_and_products.rb
@@ -2,7 +2,9 @@ class CreateItemsAndProducts < ActiveRecord::Migration
   def change
     create_table :entities do |t|
       t.string :name
-      t.references :entity, polymorphic: true
+      # replaces `t.references :entity, polymorphic: true` to add limit: 255
+      t.integer :entity_id
+      t.string :entity_type
     end
     create_table :organisations do |t|
     end

--- a/db/migrate/20140206025958_create_items_and_products.rb
+++ b/db/migrate/20140206025958_create_items_and_products.rb
@@ -2,13 +2,13 @@ class CreateItemsAndProducts < ActiveRecord::Migration
   def change
     create_table :entities do |t|
       t.string :name
-      t.references :entity, :polymorphic => true
+      t.references :entity, polymorphic: true
     end
     create_table :organisations do |t|
     end
     create_table :products do |t|
       t.string :name
-      t.integer :gtin, :limit => 8
+      t.integer :gtin, limit: 8
     end
     create_table :items do |t|
       t.references :product

--- a/db/migrate/20140215032346_change_product.rb
+++ b/db/migrate/20140215032346_change_product.rb
@@ -1,6 +1,6 @@
 class ChangeProduct < ActiveRecord::Migration
   def change
     add_column :products, :description, :text
-    add_column :products, :image, :string
+    add_column :products, :image, :string, limit: 255
   end
 end

--- a/db/migrate/20141224080737_change_language_model.rb
+++ b/db/migrate/20141224080737_change_language_model.rb
@@ -1,9 +1,9 @@
 class ChangeLanguageModel < ActiveRecord::Migration
   def change
-    add_column :languages, :source_filename, :string
-    add_column :languages, :exe_extension, :string
-    add_column :languages, :compiler_command, :string
-    add_column :languages, :interpreter, :string
-    add_column :languages, :interpreter_command, :string
+    add_column :languages, :source_filename, :string, limit: 255
+    add_column :languages, :exe_extension, :string, limit: 255
+    add_column :languages, :compiler_command, :string, limit: 255
+    add_column :languages, :interpreter, :string, limit: 255
+    add_column :languages, :interpreter_command, :string, limit: 255
   end
 end

--- a/db/migrate/20141224134542_clean_language_model.rb
+++ b/db/migrate/20141224134542_clean_language_model.rb
@@ -1,6 +1,6 @@
 class CleanLanguageModel < ActiveRecord::Migration
   def change
-    remove_column :languages, :flags, :string
+    remove_column :languages, :flags, :string, limit: 255
     add_column :languages, :processes, :integer, default: 1
   end
 end

--- a/db/migrate/20141224134542_clean_language_model.rb
+++ b/db/migrate/20141224134542_clean_language_model.rb
@@ -1,6 +1,6 @@
 class CleanLanguageModel < ActiveRecord::Migration
   def change
     remove_column :languages, :flags, :string
-    add_column :languages, :processes, :integer, :default => 1
+    add_column :languages, :processes, :integer, default: 1
   end
 end

--- a/db/migrate/20150107090445_add_data_to_item_history.rb
+++ b/db/migrate/20150107090445_add_data_to_item_history.rb
@@ -1,5 +1,5 @@
 class AddDataToItemHistory < ActiveRecord::Migration
   def change
-    add_column :item_histories, :data, :string
+    add_column :item_histories, :data, :string, limit: 255
   end
 end

--- a/db/migrate/20150109101859_add_school_country_year_to_users.rb
+++ b/db/migrate/20150109101859_add_school_country_year_to_users.rb
@@ -1,7 +1,7 @@
 class AddSchoolCountryYearToUsers < ActiveRecord::Migration
   def change
     add_column :users, :school_id, :integer
-    add_column :users, :country_code, :string, :limit => 3
+    add_column :users, :country_code, :string, limit: 3
     add_column :users, :school_graduation, :date # Year-AnyMonth-00
   end
 end

--- a/db/migrate/20150117065146_create_schools.rb
+++ b/db/migrate/20150117065146_create_schools.rb
@@ -1,7 +1,7 @@
 class CreateSchools < ActiveRecord::Migration
   def change
     create_table :schools do |t|
-      t.string :name
+      t.string :name, limit: 255
       t.string :country, limit: 2
       t.integer :users_count
     end

--- a/db/migrate/20150124223718_add_options_to_contest.rb
+++ b/db/migrate/20150124223718_add_options_to_contest.rb
@@ -1,6 +1,6 @@
 class AddOptionsToContest < ActiveRecord::Migration
   def change
-    add_column :contests, :startcode, :string # plain-text start-code
+    add_column :contests, :startcode, :string, limit: 255 # plain-text start-code
     add_column :contests, :observation, :integer, default: 1 # for observers: public (everyone), protected (groups it is added to even if not competing), private (only if competing)
     add_column :contests, :registration, :integer, default: 0 # open (to all group members), application (by all group members), invitation (to anybody), private (no invites - admin add only)
     # display school affiliation, may require school set to join contest

--- a/db/migrate/20160123214252_create_contest_supervisors.rb
+++ b/db/migrate/20160123214252_create_contest_supervisors.rb
@@ -3,7 +3,7 @@ class CreateContestSupervisors < ActiveRecord::Migration
     create_table :contest_supervisors do |t|
       t.integer :contest_id
       t.integer :user_id
-      t.string :site_type
+      t.string :site_type, limit: 255
       t.integer :site_id
 
       t.timestamps null: true

--- a/db/migrate/20200418113600_add_live_scoreboard_field.rb
+++ b/db/migrate/20200418113600_add_live_scoreboard_field.rb
@@ -1,5 +1,5 @@
 class AddLiveScoreboardField < ActiveRecord::Migration
   def change
-    add_column :contests, :live_scoreboard, :boolean, :default => true
+    add_column :contests, :live_scoreboard, :boolean, default: true
   end
 end

--- a/db/migrate/20200418113601_add_offical_contestants.rb
+++ b/db/migrate/20200418113601_add_offical_contestants.rb
@@ -1,5 +1,5 @@
 class AddOfficalContestants < ActiveRecord::Migration
   def change
-    add_column :contests, :only_rank_official_contestants, :boolean, :default => false
+    add_column :contests, :only_rank_official_contestants, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   create_table "contest_supervisors", force: :cascade do |t|
     t.integer  "contest_id"
     t.integer  "user_id"
-    t.string   "site_type"
+    t.string   "site_type",            limit: 255
     t.integer  "site_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   end
 
   create_table "contests", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",                           limit: 255
     t.datetime "start_time"
     t.datetime "end_time"
     t.decimal  "duration"
@@ -72,45 +72,45 @@ ActiveRecord::Schema.define(version: 20250318053450) do
     t.datetime "updated_at"
     t.integer  "problem_set_id"
     t.datetime "finalized_at"
-    t.string   "startcode"
-    t.integer  "observation",                    default: 1
-    t.integer  "registration",                   default: 0
-    t.integer  "affiliation",                    default: 0
-    t.boolean  "live_scoreboard",                default: true
-    t.boolean  "only_rank_official_contestants", default: false
+    t.string   "startcode",                      limit: 255
+    t.integer  "observation",                                default: 1
+    t.integer  "registration",                               default: 0
+    t.integer  "affiliation",                                default: 0
+    t.boolean  "live_scoreboard",                            default: true
+    t.boolean  "only_rank_official_contestants",             default: false
   end
 
   create_table "entities", force: :cascade do |t|
-    t.string  "name"
+    t.string  "name",        limit: 255
     t.integer "entity_id"
-    t.string  "entity_type"
+    t.string  "entity_type", limit: 255
   end
 
   create_table "evaluators", force: :cascade do |t|
-    t.string   "name",                     null: false
-    t.text     "description", default: "", null: false
-    t.text     "source",      default: "", null: false
-    t.integer  "owner_id",                 null: false
+    t.string   "name",        limit: 255,              null: false
+    t.text     "description",             default: "", null: false
+    t.text     "source",                  default: "", null: false
+    t.integer  "owner_id",                             null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "language_id"
   end
 
   create_table "file_attachments", force: :cascade do |t|
-    t.string   "name"
-    t.string   "file_attachment"
+    t.string   "name",            limit: 255
+    t.string   "file_attachment", limit: 255
     t.integer  "owner_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
   end
 
   create_table "filelinks", force: :cascade do |t|
     t.integer  "root_id"
     t.integer  "file_attachment_id"
     t.datetime "created_at"
-    t.string   "filepath"
-    t.string   "root_type"
-    t.integer  "visibility",         limit: 2, default: 0
+    t.string   "filepath",           limit: 255
+    t.string   "root_type",          limit: 255
+    t.integer  "visibility",         limit: 2,   default: 0
   end
 
   add_index "filelinks", ["file_attachment_id"], name: "index_filelinks_on_file_attachment_id", using: :btree
@@ -133,19 +133,19 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   create_table "group_problem_sets", force: :cascade do |t|
     t.integer "group_id"
     t.integer "problem_set_id"
-    t.string  "name"
+    t.string  "name",           limit: 255
   end
 
   add_index "group_problem_sets", ["group_id", "problem_set_id"], name: "index_group_problem_sets_on_group_id_and_problem_set_id", using: :btree
   add_index "group_problem_sets", ["problem_set_id", "group_id"], name: "index_group_problem_sets_on_problem_set_id_and_group_id", using: :btree
 
   create_table "groups", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "owner_id"
-    t.integer  "visibility", default: 0, null: false
-    t.integer  "membership", default: 0, null: false
+    t.integer  "visibility",             default: 0, null: false
+    t.integer  "membership",             default: 0, null: false
   end
 
   create_table "item_histories", force: :cascade do |t|
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 20250318053450) do
     t.boolean  "active"
     t.integer  "action"
     t.integer  "holder_id"
-    t.string   "data"
+    t.string   "data",       limit: 255
     t.datetime "acted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -172,32 +172,32 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   end
 
   create_table "language_groups", force: :cascade do |t|
-    t.string   "identifier"
-    t.string   "name"
+    t.string   "identifier",          limit: 255
+    t.string   "name",                limit: 255
     t.integer  "current_language_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   add_index "language_groups", ["identifier"], name: "index_language_groups_on_identifier", unique: true, using: :btree
 
   create_table "languages", force: :cascade do |t|
-    t.string   "identifier"
-    t.string   "compiler"
+    t.string   "identifier",          limit: 255
+    t.string   "compiler",            limit: 255
     t.boolean  "interpreted"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "extension"
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
+    t.string   "extension",           limit: 255
     t.boolean  "compiled"
-    t.string   "name"
-    t.string   "lexer"
+    t.string   "name",                limit: 255
+    t.string   "lexer",               limit: 255
     t.integer  "group_id"
-    t.string   "source_filename"
-    t.string   "exe_extension"
-    t.string   "compiler_command"
-    t.string   "interpreter"
-    t.string   "interpreter_command"
-    t.integer  "processes",           default: 1
+    t.string   "source_filename",     limit: 255
+    t.string   "exe_extension",       limit: 255
+    t.string   "compiler_command",    limit: 255
+    t.string   "interpreter",         limit: 255
+    t.string   "interpreter_command", limit: 255
+    t.integer  "processes",                       default: 1
   end
 
   add_index "languages", ["identifier"], name: "index_languages_on_identifier", unique: true, using: :btree
@@ -206,9 +206,9 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   end
 
   create_table "problem_series", force: :cascade do |t|
-    t.string "name"
-    t.string "identifier"
-    t.string "importer_type"
+    t.string "name",          limit: 255
+    t.string "identifier",    limit: 255
+    t.string "importer_type", limit: 255
     t.text   "index_yaml"
   end
 
@@ -223,18 +223,18 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   add_index "problem_set_problems", ["problem_set_id", "problem_id"], name: "index_problem_set_problems_on_problem_set_id_and_problem_id", using: :btree
 
   create_table "problem_sets", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",                     limit: 255
     t.integer  "owner_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "finalized_contests_count", default: 0
+    t.integer  "finalized_contests_count",             default: 0
   end
 
   create_table "problems", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",               limit: 255
     t.text     "statement"
-    t.string   "input"
-    t.string   "output"
+    t.string   "input",              limit: 255
+    t.string   "output",             limit: 255
     t.integer  "memory_limit"
     t.decimal  "time_limit"
     t.integer  "owner_id"
@@ -242,34 +242,34 @@ ActiveRecord::Schema.define(version: 20250318053450) do
     t.datetime "updated_at"
     t.integer  "evaluator_id"
     t.datetime "rejudge_at"
-    t.integer  "test_error_count",   default: 0
-    t.integer  "test_warning_count", default: 0
-    t.integer  "test_status",        default: 0
+    t.integer  "test_error_count",               default: 0
+    t.integer  "test_warning_count",             default: 0
+    t.integer  "test_status",                    default: 0
   end
 
   create_table "products", force: :cascade do |t|
-    t.string  "name"
+    t.string  "name",        limit: 255
     t.integer "gtin",        limit: 8
     t.text    "description"
-    t.string  "image"
+    t.string  "image",       limit: 255
   end
 
   create_table "requests", force: :cascade do |t|
     t.integer  "requester_id"
     t.integer  "subject_id"
-    t.string   "subject_type"
-    t.string   "verb",                              null: false
-    t.integer  "target_id",                         null: false
-    t.string   "target_type",                       null: false
-    t.integer  "status",       default: 0,          null: false
+    t.string   "subject_type", limit: 255
+    t.string   "verb",         limit: 255,                      null: false
+    t.integer  "target_id",                                     null: false
+    t.string   "target_type",  limit: 255,                      null: false
+    t.integer  "status",                   default: 0,          null: false
     t.integer  "requestee_id"
-    t.datetime "expired_at",   default: 'Infinity', null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "expired_at",               default: 'Infinity', null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
   end
 
   create_table "roles", force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 255
   end
 
   create_table "roles_users", id: false, force: :cascade do |t|
@@ -278,14 +278,14 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   end
 
   create_table "schools", force: :cascade do |t|
-    t.string  "name"
+    t.string  "name",         limit: 255
     t.string  "country_code", limit: 2
     t.integer "users_count"
     t.integer "synonym_id"
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", null: false
+    t.string   "session_id", limit: 255, null: false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -296,8 +296,8 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "settings", force: :cascade do |t|
-    t.string "key"
-    t.string "value"
+    t.string "key",   limit: 255
+    t.string "value", limit: 255
   end
 
   add_index "settings", ["key"], name: "index_settings_on_key", unique: true, using: :btree
@@ -309,15 +309,15 @@ ActiveRecord::Schema.define(version: 20250318053450) do
     t.integer  "problem_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "input"
-    t.string   "output"
+    t.string   "input",          limit: 255
+    t.string   "output",         limit: 255
     t.integer  "language_id"
     t.text     "judge_log"
     t.datetime "judged_at"
-    t.string   "job"
+    t.string   "job",            limit: 255
     t.integer  "classification"
-    t.string   "test_errors",    array: true
-    t.string   "test_warnings",  array: true
+    t.string   "test_errors",    limit: 255, array: true
+    t.string   "test_warnings",  limit: 255, array: true
     t.float    "evaluation"
     t.decimal  "points"
     t.integer  "maximum_points"
@@ -339,11 +339,11 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   create_table "test_cases", force: :cascade do |t|
     t.text     "input"
     t.text     "output"
-    t.string   "name"
+    t.string   "name",          limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "problem_id"
-    t.boolean  "sample",        default: false
+    t.boolean  "sample",                    default: false
     t.integer  "problem_order"
   end
 
@@ -352,10 +352,10 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   create_table "test_sets", force: :cascade do |t|
     t.integer  "problem_id"
     t.integer  "points"
-    t.string   "name"
+    t.string   "name",          limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "prerequisite",  default: false
+    t.boolean  "prerequisite",              default: false
     t.integer  "problem_order"
   end
 
@@ -378,27 +378,27 @@ ActiveRecord::Schema.define(version: 20250318053450) do
   add_index "user_problem_relations", ["user_id", "problem_id"], name: "index_user_problem_relations_on_user_id_and_problem_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                            default: "",    null: false
-    t.string   "encrypted_password",               default: "",    null: false
-    t.string   "reset_password_token"
+    t.string   "email",                  limit: 255, default: "",    null: false
+    t.string   "encrypted_password",     limit: 255, default: "",    null: false
+    t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                    default: 0
+    t.integer  "sign_in_count",                      default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
+    t.string   "current_sign_in_ip",     limit: 255
+    t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "brownie_points",                   default: 0
-    t.string   "name"
-    t.string   "username",                                         null: false
-    t.boolean  "can_change_username",              default: false, null: false
-    t.string   "avatar"
-    t.string   "confirmation_token"
+    t.integer  "brownie_points",                     default: 0
+    t.string   "name",                   limit: 255
+    t.string   "username",               limit: 255,                 null: false
+    t.boolean  "can_change_username",                default: false, null: false
+    t.string   "avatar",                 limit: 255
+    t.string   "confirmation_token",     limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
+    t.string   "unconfirmed_email",      limit: 255
     t.datetime "last_seen_at"
     t.integer  "school_id"
     t.string   "country_code",           limit: 3


### PR DESCRIPTION
From the main commit's message:

> There used to be a default limit of 255 characters on string columns,
> but that was removed in Rails 4.2 [1][2].
> 
> Explicitly set the limit to 255 in the migrations so that they will
> retain their old behaviour.
> 
> ...
> 
> [1] https://guides.rubyonrails.org/v4.2/4_2_release_notes.html#active-record-notable-changes
> [2] https://www.github.com/rails/rails/pull/14579

Discussed in https://github.com/NZOI/nztrain/pull/225#issuecomment-1876932087 and https://github.com/NZOI/nztrain/pull/243#issuecomment-1879999281.

(Intended merge strategy: rebase or merge commit.)