### PR TITLE
Bump pygments.rb from 1.1.2 to 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'simple_form', '3.2.1'
 gem 'facebox-rails'
 gem 'strong_presenter', '~> 0.2.2'
 gem 'render_anywhere'
-gem 'pygments.rb', '~> 1.1.0'
+gem 'pygments.rb', '~> 2.0'
 gem 'ranked-model', '< 0.4.3' # pinned because 0.4.3-0.4.4 are broken (see https://github.com/brendon/ranked-model/issues/139; we also need the fix in https://github.com/brendon/ranked-model/pull/152); we can't update to 0.4.5 yet because it requires activerecord >= 4.2
 gem 'pdf-reader'
 gem 'mechanize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,6 @@ GEM
     minitest (5.15.0)
     money (6.10.1)
       i18n (>= 0.6.4, < 1.0)
-    multi_json (1.15.0)
     multipart-post (2.3.0)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
@@ -251,8 +250,7 @@ GEM
     public_suffix (4.0.7)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    pygments.rb (1.1.2)
-      multi_json (>= 1.0.0)
+    pygments.rb (2.3.1)
     racc (1.5.2)
     rack (1.6.13)
     rack-protection (1.5.5)
@@ -465,7 +463,7 @@ DEPENDENCIES
   prawn
   psych (~> 2.0.2)
   pundit (~> 1.1.0)
-  pygments.rb (~> 1.1.0)
+  pygments.rb (~> 2.0)
   qless!
   rails (~> 4.2)
   ranked-model (< 0.4.3)


### PR DESCRIPTION
pygments.rb >= 2.0.0 runs on Python 3.x instead of Python 2.7 [1], so this allows us to run on systems without Python 2 installed.

[1] https://github.com/pygments/pygments.rb/blob/master/CHANGELOG.adoc#200rc1-2021-01-07---slonopotamus

---

@tom93 previously mentioned that pygments.rb 2.0.0 had changes related to timeout handling in #164. I haven't looked into that too much but I didn't notice any issues.

Note that this is required to update CI to run on Ubuntu 22 or 24 (which no longer comes with Python 2); see 1266f26 and 6674efa. We'll need to upgrade soon since support for Ubuntu 20 is being removed next month. Does anyone have a preference between Ubuntu 22 vs 24/latest? latest is at least ~30 slower since it doesn't come with imagemagick preinstalled.