### PR TITLE
Update GitHub Actions workflow to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:11-alpine
@@ -68,7 +68,7 @@ jobs:
       - uses: coverallsapp/github-action@v2
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
It was previously running on ubuntu-20.04, but that is deprecated and will soon be fully unsupported [1].

[1] https://www.github.com/actions/runner-images/issues/11101

Was discussed briefly in #276.