### PR TITLE
Remove gem "jquery-historyjs"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'rubyzip', '1.3.0'
 
 gem 'jquery-rails', '~> 3.1.3'
 gem 'jquery-ui-rails', '4.0.5'
-gem 'jquery-historyjs', '0.2.3'
 gem 'superfish-rails', '~> 1.6.0'
 
 gem 'nokogiri', '~> 1.10.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,9 +175,6 @@ GEM
     jquery-final_countdown-rails (2.0.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    jquery-historyjs (0.2.3)
-      railties (>= 3.0)
-      thor (>= 0.14)
     jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -449,7 +446,6 @@ DEPENDENCIES
   foreman
   has_scope
   jquery-final_countdown-rails
-  jquery-historyjs (= 0.2.3)
   jquery-rails (~> 3.1.3)
   jquery-ui-rails (= 4.0.5)
   json_cve_2020_10663 (~> 1.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,7 +8,6 @@
 //= require jquery.url
 //= require hoverIntent
 //= require superfish
-//= require history
 //= require jquery.facebox
 //= require jquery.facebox.adapter
 //= require_self


### PR DESCRIPTION
We no longer use it directly (via 'History'), and we don't try to support ancient web browsers.