### PR TITLE
Update json gem to 2.7.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby ">= 2.4.10", "< 2.5"
 
 gem "rails", "~> 4.2"
-gem "json_cve_2020_10663", "~> 1.0" # required until we update json >= 2.3, which we can only do once we upgrade to Rails >= 4.2 because activesupport 4.1.* depends on json ~> 1.7 (i.e < 2.0): https://rubygems.org/gems/activesupport/versions/4.1.16
 
 gem "devise", "~> 4.0"
 gem "psych", "~> 2.0.2" # part of stdlib, need newer version for safe_load

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,9 +168,7 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n_data (0.8.0)
     iso8601 (0.10.1)
-    json (1.8.6)
-    json_cve_2020_10663 (1.0.0)
-      json (>= 1.7.7, < 2.3)
+    json (2.7.6)
     libv8-node (15.14.0.1)
     loofah (2.3.1)
       crass (~> 1.0.2)
@@ -437,7 +435,6 @@ DEPENDENCIES
   factory_bot_rails
   foreman
   has_scope
-  json_cve_2020_10663 (~> 1.0)
   loofah
   mechanize
   mini_racer (~> 0.4.0)


### PR DESCRIPTION
Now that we've updated to Rails 4.2 we can update json to >= 2.3 and remove the CVE patch.