### PR TITLE
Remove caching from controller permitted_params etc.

### DIFF
--- a/app/controllers/accounts/settings_controller.rb
+++ b/app/controllers/accounts/settings_controller.rb
@@ -1,7 +1,7 @@
 class Accounts::SettingsController < Devise::RegistrationsController
   def permitted_params
-    @_permitted_attributes ||= [:name, :avatar, :remove_avatar, :avatar_cache, :country_code, :school_id, {school_graduation: [:enabled, :month, :year], school: [:name, :country_code]}]
-    params.require(:user).permit(*@_permitted_attributes)
+    permitted_attributes = [:name, :avatar, :remove_avatar, :avatar_cache, :country_code, :school_id, {school_graduation: [:enabled, :month, :year], school: [:name, :country_code]}]
+    params.require(:user).permit(*permitted_attributes)
   end
 
   def update

--- a/app/controllers/contest_relations_controller.rb
+++ b/app/controllers/contest_relations_controller.rb
@@ -2,10 +2,8 @@ class ContestRelationsController < ApplicationController
   # filter_resource_access
 
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:user_id, :contest_id, :started_at]
-      params.require(:contest_relation).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:user_id, :contest_id, :started_at]
+    params.require(:contest_relation).permit(*permitted_attributes)
   end
 
   # GET /contest_relations

--- a/app/controllers/contest_supervisors_controller.rb
+++ b/app/controllers/contest_supervisors_controller.rb
@@ -2,10 +2,8 @@ class ContestSupervisorsController < ApplicationController
   # filter_resource_access
 
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:username, :contest_id, :site_type, :site_id]
-      params.require(:contest_supervisor).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:username, :contest_id, :site_type, :site_id]
+    params.require(:contest_supervisor).permit(*permitted_attributes)
   end
 
   def update_scheduled_time

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -1,10 +1,8 @@
 class ContestsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:name, :start_time, :end_time, :duration, :problem_set_id, :startcode, :observation, :live_scoreboard, :only_rank_official_contestants]
-      permitted_attributes << :owner_id if policy(@contest || Contest).transfer?
-      params.require(:contest).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:name, :start_time, :end_time, :duration, :problem_set_id, :startcode, :observation, :live_scoreboard, :only_rank_official_contestants]
+    permitted_attributes << :owner_id if policy(@contest || Contest).transfer?
+    params.require(:contest).permit(*permitted_attributes)
   end
 
   # GET /contests

--- a/app/controllers/evaluators_controller.rb
+++ b/app/controllers/evaluators_controller.rb
@@ -1,10 +1,8 @@
 class EvaluatorsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:name, :description, :source, :language_id]
-      permitted_attributes << :owner_id if policy(@evaluator || Evaluator).transfer?
-      params.require(:evaluator).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:name, :description, :source, :language_id]
+    permitted_attributes << :owner_id if policy(@evaluator || Evaluator).transfer?
+    params.require(:evaluator).permit(*permitted_attributes)
   end
 
   # GET /evaluators

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -1,11 +1,9 @@
 class FileAttachmentsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:name_type, :file_attachment, :file_attachment_cache]
-      permitted_attributes << :owner_id if policy(@file_attachment || FileAttachment).transfer?
-      permitted_attributes << :name if params.require(:file_attachment)[:name_type] == "other"
-      params.require(:file_attachment).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:name_type, :file_attachment, :file_attachment_cache]
+    permitted_attributes << :owner_id if policy(@file_attachment || FileAttachment).transfer?
+    permitted_attributes << :name if params.require(:file_attachment)[:name_type] == "other"
+    params.require(:file_attachment).permit(*permitted_attributes)
   end
 
   # GET /file_attachments

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,11 +1,8 @@
 class GroupsController < ApplicationController
   def permitted_params
-    @_permitted_attributes ||= begin
-      permitted_attributes = [:name, :visibility, :membership]
-      permitted_attributes << :owner_id if policy(@group || Group).transfer?
-      permitted_attributes
-    end
-    params.require(:group).permit(*@_permitted_attributes)
+    permitted_attributes = [:name, :visibility, :membership]
+    permitted_attributes << :owner_id if policy(@group || Group).transfer?
+    params.require(:group).permit(*permitted_attributes)
   end
 
   def add_contest

--- a/app/controllers/problem_sets_controller.rb
+++ b/app/controllers/problem_sets_controller.rb
@@ -1,10 +1,8 @@
 class ProblemSetsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:name, problem_associations_attributes: [:id, :problem_set_order_position, :weighting]]
-      permitted_attributes << :owner_id if policy(@problem_set || ProblemSet).transfer?
-      params.require(:problem_set).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:name, problem_associations_attributes: [:id, :problem_set_order_position, :weighting]]
+    permitted_attributes << :owner_id if policy(@problem_set || ProblemSet).transfer?
+    params.require(:problem_set).permit(*permitted_attributes)
   end
 
   # unused

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -1,33 +1,25 @@
 class ProblemsController < ApplicationController
   def permitted_params
-    @_permitted_attributes ||= begin
-      permitted_attributes = [:name, :statement, :memory_limit, :time_limit, :input_type, :output_type, :evaluator_id]
-      permitted_attributes << :owner_id if policy(@problem || Problem).transfer?
-      permitted_attributes << :input if params.require(:problem)[:input_type] == "file"
-      permitted_attributes << :output if params.require(:problem)[:output_type] == "file"
-      permitted_attributes
-    end
-    params.require(:problem).permit(*@_permitted_attributes)
+    permitted_attributes = [:name, :statement, :memory_limit, :time_limit, :input_type, :output_type, :evaluator_id]
+    permitted_attributes << :owner_id if policy(@problem || Problem).transfer?
+    permitted_attributes << :input if params.require(:problem)[:input_type] == "file"
+    permitted_attributes << :output if params.require(:problem)[:output_type] == "file"
+    params.require(:problem).permit(*permitted_attributes)
   end
 
   # attributes allowed to be included in submissions
   def submit_params
-    @_submit_attributes ||= begin
-      submit_attributes = [:language_id, :source_file]
-      submit_attributes << :source if policy(@problem).submit_source?
-      submit_attributes
-    end
-    params.require(:submission).permit(*@_submit_attributes).merge(user_id: current_user.id, problem_id: params[:id])
+    submit_attributes = [:language_id, :source_file]
+    submit_attributes << :source if policy(@problem).submit_source?
+    params.require(:submission).permit(*submit_attributes).merge(user_id: current_user.id, problem_id: params[:id])
   end
 
   def visible_attributes
-    @_visible_attributes ||= begin
-      visible_attributes = [:linked_name, :input, :output, :memory_limit, :time_limit, :linked_owner, :progress_bar]
-      visible_attributes << :edit_link if policy(@problem).update?
-      visible_attributes << :destroy_link if policy(@problem).destroy?
-      visible_attributes << :test_status if policy(@problem).inspect?
-      visible_attributes
-    end
+    visible_attributes = [:linked_name, :input, :output, :memory_limit, :time_limit, :linked_owner, :progress_bar]
+    visible_attributes << :edit_link if policy(@problem).update?
+    visible_attributes << :destroy_link if policy(@problem).destroy?
+    visible_attributes << :test_status if policy(@problem).inspect?
+    visible_attributes
   end
 
   # GET /problems

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,9 +1,7 @@
 class RolesController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:name]
-      params.require(:role).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:name]
+    params.require(:role).permit(*permitted_attributes)
   end
 
   # GET /roles

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,9 +1,7 @@
 class SchoolsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:name]
-      params.require(:school).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:name]
+    params.require(:school).permit(*permitted_attributes)
   end
 
   def index

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,9 +1,7 @@
 class SettingsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:key, :value]
-      params.require(:setting).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:key, :value]
+    params.require(:setting).permit(*permitted_attributes)
   end
 
   # GET /settings

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,10 +1,8 @@
 class SubmissionsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:problem_id, :source, :language_id]
-      permitted_attributes << :classification if policy(@submission).allowed_classifications.include?(params[:submission][:classification].to_i)
-      params.require(:submission).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:problem_id, :source, :language_id]
+    permitted_attributes << :classification if policy(@submission).allowed_classifications.include?(params[:submission][:classification].to_i)
+    params.require(:submission).permit(*permitted_attributes)
   end
 
   has_scope :by_user

--- a/app/controllers/test_cases_controller.rb
+++ b/app/controllers/test_cases_controller.rb
@@ -2,10 +2,8 @@ class TestCasesController < ApplicationController
   # filter_resource_access :collection => []
 
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:input, :output, :name]
-      params.require(:test_case).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:input, :output, :name]
+    params.require(:test_case).permit(*permitted_attributes)
   end
 
   # GET /test_cases

--- a/app/controllers/test_sets_controller.rb
+++ b/app/controllers/test_sets_controller.rb
@@ -1,9 +1,7 @@
 class TestSetsController < ApplicationController
   def permitted_params
-    @_permitted_params ||= begin
-      permitted_attributes = [:name, :problem_id, :points]
-      params.require(:test_set).permit(*permitted_attributes)
-    end
+    permitted_attributes = [:name, :problem_id, :points]
+    params.require(:test_set).permit(*permitted_attributes)
   end
 
   # GET /test_sets

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,20 +1,9 @@
 class UserController < ApplicationController
   # this is for admins, users edit their own accounts using the accounts/ scope
   def permitted_params
-    @_permitted_attributes ||= begin
-      permitted_attributes = [:name, :avatar, :remove_avatar, :avatar_cache, :email, :school_id]
-      permitted_attributes << :brownie_points if policy(@user).add_brownie?
-      permitted_attributes
-    end
-    params.require(:user).permit(*@_permitted_attributes)
-  end
-
-  def visible_attributes
-    @_visible_attributes ||= begin
-      visible_attributes = [:username]
-      visible_attributes += [:name, :email] if policy(@user).inspect?
-      visible_attributes
-    end
+    permitted_attributes = [:name, :avatar, :remove_avatar, :avatar_cache, :email, :school_id]
+    permitted_attributes << :brownie_points if policy(@user).add_brownie?
+    params.require(:user).permit(*permitted_attributes)
   end
 
   def show


### PR DESCRIPTION
We don't call these methods multiple times during a single request, so there is no point in caching the result. (The example from the original strong_parameters gem doesn't use caching: https://github.com/rails/strong_parameters.)

This also eliminates silly inconsistencies with what was cached -- in some places it was @_permitted_params, while in other places it was the intermediate @_permitted_attributes.

Also remove method `visible_attributes` from user_controller.rb, it's unused since commit 8798951a (Refactor to remove the UserPresenter service object (#165), 2023-02-18).