### PR TITLE
Remove unused actions on ContestRelationsController

### DIFF
--- a/app/controllers/contest_relations_controller.rb
+++ b/app/controllers/contest_relations_controller.rb
@@ -1,111 +1,38 @@
 class ContestRelationsController < ApplicationController
-  # filter_resource_access
+  before_action :authenticate_user!
+  before_filter :find_contest_relation
 
-  def permitted_params
-    permitted_attributes = [:user_id, :contest_id, :started_at]
-    params.require(:contest_relation).permit(*permitted_attributes)
-  end
-
-  # GET /contest_relations
-  # GET /contest_relations.xml
-  def index
-    @contest_relations = ContestRelation.all
-
-    respond_to do |format|
-      format.html # index.html.erb
-      format.xml { render xml: @contest_relations }
-    end
-  end
-
-  # GET /contest_relations/1
-  # GET /contest_relations/1.xml
-  def show
-    @contest_relation = ContestRelation.find(params[:id])
-
-    respond_to do |format|
-      format.html # show.html.erb
-      format.xml { render xml: @contest_relation }
-    end
-  end
-
-  # GET /contest_relations/new
-  # GET /contest_relations/new.xml
-  def new
-    @contest = Contest.new
-    @start_time = ""
-    @end_time = ""
-
-    respond_to do |format|
-      format.html # new.html.erb
-      format.xml { render xml: @contest }
-    end
-  end
-
-  # GET /contest_relations/1/edit
-  def edit
-    @contest_relation = ContestRelation.find(params[:id])
-  end
-
-  # POST /contest_relations
-  # POST /contest_relations.xml
-  def create
-    @contest_relation = ContestRelation.new(permitted_params)
-    authorize @contest_relation, :create?
-
-    respond_to do |format|
-      if @contest_relation.save
-        format.html { redirect_to(@contest_relation, notice: "Contest relation was successfully created.") }
-        format.xml { render xml: @contest_relation, status: :created, location: @contest_relation }
-      else
-        format.html { render action: "new" }
-        format.xml { render xml: @contest_relation.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PUT /contest_relations/1
-  # PUT /contest_relations/1.xml
-  def update
-    respond_to do |format|
-      if @contest_relation.update_attributes(permitted_params)
-        format.html { redirect_to(@contest_relation, notice: "Contest relation was successfully updated.") }
-        format.xml { head :ok }
-      else
-        format.html { render action: "edit" }
-        format.xml { render xml: @contest_relation.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # DELETE /contest_relations/1
-  # DELETE /contest_relations/1.xml
   def destroy
-    @contest_relation = ContestRelation.find(params[:id])
-
     authorize @contest_relation, :destroy?
 
-    respond_to do |format|
-      if @contest_relation.destroy
-        format.html { redirect_to(contestants_contest_path(@contest_relation.contest), notice: "Contestant deleted") }
-      else
-        format.html { redirect_to(contestants_contest_path(@contest_relation.contest), alert: "Could not delete contestant") }
-      end
+    if @contest_relation.destroy
+      redirect_to(contestants_contest_path(@contest_relation.contest), notice: "Contestant deleted")
+    else
+      redirect_to(contestants_contest_path(@contest_relation.contest), alert: "Could not delete contestant")
     end
   end
 
   def update_year_level
-    @contest_relation = ContestRelation.find(params[:id])
     authorize @contest_relation, :supervise?
+
     if params[:year_level]
       year_level = params[:year_level].to_i % 15
       @contest_relation.school_year = if year_level != 14
         year_level
       end
+
       if @contest_relation.save
         redirect_to(contestants_contest_path(@contest_relation.contest), notice: "Contestant year level updated")
         return
       end
     end
+
     redirect_to(contestants_contest_path(@contest_relation.contest), alert: "Could not update year level of contestant")
+  end
+
+  private
+
+  def find_contest_relation
+    @contest_relation = ContestRelation.find(params[:id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,6 @@ NZTrain::Application.routes.draw do
     end
   end
 
-  # resources :contest_relations
   resources :contest_relations, only: :destroy do
     member do
       post "update_year_level"

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,0 +1,7 @@
+# Read about factories at https://github.com/thoughtbot/factory_bot
+
+FactoryBot.define do
+  factory :school do
+    sequence(:name) { |n| "School #{n}" }
+  end
+end

--- a/spec/requests/contest_relations_request_spec.rb
+++ b/spec/requests/contest_relations_request_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+
+RSpec.describe ContestRelationsController, type: :request do
+  let(:student) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:superadmin) }
+  let(:contest) { FactoryBot.create(:contest) }
+  let(:school) { FactoryBot.create(:school) }
+  let!(:contest_relation) { FactoryBot.create(:contest_relation, user: student, school: school, contest: contest) }
+
+  before do
+    sign_in(user) if user
+  end
+
+  describe "DELETE /contest_relations/:id" do
+    context "when not signed in" do
+      let(:user) { nil }
+
+      context "when the relation exists" do
+        it "doesn't remove the relation" do
+          expect { delete "/contest_relations/#{contest_relation.id}" }
+            .not_to change { contest.reload.contest_relations.count }
+        end
+
+        it "redirects to login page" do
+          delete "/contest_relations/#{contest_relation.id}"
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+
+      context "when the relation doesn't exist" do
+        let(:contest_relation) { nil }
+
+        it "redirect to login page" do
+          delete "/contest_relations/1"
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+    end
+
+    context "when signed in as a superadmin" do
+      let(:user) { FactoryBot.create(:superadmin) }
+
+      context "when the relation exists" do
+        it "removes the relation" do
+          expect { delete "/contest_relations/#{contest_relation.id}" }
+            .to change { contest.reload.contest_relations.count }
+            .from(1).to(0)
+        end
+      end
+
+      context "when the relation doesn't exist" do
+        let(:contest_relation) { nil }
+
+        it "raises an exception" do
+          expect { delete "/contest_relations/1" }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+
+  describe "POST /contest_relations/:id/update_year_level" do
+    context "when signed in a supervisor of this contest" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        contest.contest_supervisors.create!(user: user, site: school)
+      end
+
+      context "when selecting a year level between 1-13" do
+        it "updates the year level" do
+          expect {
+            post "/contest_relations/#{contest_relation.id}/update_year_level", {year_level: 12}
+          }
+            .to change { contest_relation.reload.school_year }
+            .from(nil).to(12)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
   end
 
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FixturesSpecHelper, type: :controller # supply fixtures variables
   config.include ControllersSpecHelper, type: :controller # some macros for testing controllers
   config.render_views # don't stub views when testing controllers


### PR DESCRIPTION
Most of these actions were rendered unused in 2da020ef59c5, #destroy was
restored and #update_year_level added in 00c9636d1364. The rest of these
sections seem to be dead code, so lets remove them! Git history can
always bring them back as needed, but none of the code is particularly
interesting so it'd be easy to rewrite, anyway.

I've also specs to cover off the major functions of
contest_relations_controller, including some permission tests, and
ensured that there is at least a logged in user to slightly mitigate a
leak of information in the response differing between not_found and
unathorised on ContestRelation objects.
