### PR TITLE
Add a version constraint on loofah

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "will_paginate"
 gem "has_scope"
 gem "pundit", "~> 1.1.0"
 gem "recaptcha", require: "recaptcha/rails"
-gem "loofah"
+gem "loofah", "<= 2.20.0"
 gem "whenever", require: false # for cron jobs
 gem "squeel" # , '~> 1.1.1' # until version 1.1.2 released
 gem "tilt"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,7 +435,7 @@ DEPENDENCIES
   factory_bot_rails
   foreman
   has_scope
-  loofah
+  loofah (<= 2.20.0)
   mechanize
   mini_racer (~> 0.4.0)
   newrelic_rpm


### PR DESCRIPTION
Loofah 2.21.0 added support for HTML5 (as did a later version of
Nokogiri which loofah is based off). However, we can't upgrade Nokogiri
yet due to a higher ruby version requirement. The nokogiri dependencies
aren't well constrainted for in loofah 2.21.0 so we can just stay below
that version for now, until we can upgrade ruby to 2.5, which is after
we can upgrade Rails to 5.1.

https://github.com/flavorjones/loofah/blob/main/CHANGELOG.md#2210--2023-05-10
