### PR TITLE
Configure rspec persistence path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 /coverage/
 /vendor/bundle
 
+
+rspec-examples.txt

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ RSpec.configure do |config|
   # config.mock_with :flexmock
   # config.mock_with :rr
 
+  config.example_status_persistence_file_path = "rspec-examples.txt"
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
This lets you use rspec features like "--only-failures" or
"--next-failure" which are very helpful when working your way through a
large change which caused a lot of test failures.

More info: https://rspec.info/features/3-12/rspec-core/command-line/only-failures/