### PR TITLE
Configure the hybrid cookie session store

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,0 +1,5 @@
+# Be sure to restart your server when you modify this file.
+
+# Specify a serializer for the signed and encrypted cookie jars.
+# Valid options are :json, :marshal, and :hybrid.
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
Rails 4.1 introduced the new JSON format, and it becomes default in
Rails 5.0. We want to be using hybrid in production for a period of time
in order to migrate everyone to JSON before letting JSON be the default.

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#cookies-serializer