### PR TITLE
Fix regression in updating weighting for contest problem set problems.

### DIFF
--- a/app/models/problem_set_problem.rb
+++ b/app/models/problem_set_problem.rb
@@ -12,7 +12,7 @@ class ProblemSetProblem < ActiveRecord::Base
   after_save do
     if weighting_changed?
       problem_set.contests.where(finalized_at: nil).find_each do |contest|
-        ContestScore.joins(:contest_relation).where(contest_relation: {contest_id: contest.id}, problem_id: problem_id).select([:contest_relation_id, :problem_id, :id, :score, :attempts, :attempt, :submission_id, :updated_at]).find_each do |contest_score|
+        ContestScore.joins(:contest_relation).where(contest_relations: {contest_id: contest.id}, problem_id: problem_id).select([:contest_relation_id, :problem_id, :id, :score, :attempts, :attempt, :submission_id, :updated_at]).find_each do |contest_score|
           contest_score.recalculate_and_save
         end
       end

--- a/spec/factories/contest_scores.rb
+++ b/spec/factories/contest_scores.rb
@@ -2,12 +2,11 @@
 
 FactoryBot.define do
   factory :contest_score do
-    user_id { 0 }
     contest_relation_id { 0 }
     problem_id { 0 }
     score { 0 }
-    attempts { 0 }
-    attempt { 0 }
+    attempts { 1 }
+    attempt { 1 }
     submission_id { 0 }
   end
 end

--- a/spec/models/problem_set_problem_spec.rb
+++ b/spec/models/problem_set_problem_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe ProblemSetProblem, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+
+  let(:problem) { FactoryBot.create(:problem) }
+  let(:problem_set) { FactoryBot.create(:problem_set) }
+
+  let(:contest) { FactoryBot.create(:contest, problem_set: problem_set) }
+  let(:contest_relation) { FactoryBot.create(:contest_relation, contest: contest, user: user) }
+  let!(:contest_score) { FactoryBot.create(:contest_score, contest_relation: contest_relation, problem: problem, score: 100) }
+  let!(:submission) { FactoryBot.create(:submission, problem: problem, user: user, created_at: contest_relation.started_at + 1.second, points: 10, maximum_points: 10) }
+
+  subject(:problem_set_problem) { ProblemSetProblem.create!(problem: problem, problem_set: problem_set) }
+
+  describe "#after_save" do
+    it "recalculates affected contest scores" do
+      problem_set_problem.weighting = 50
+
+      expect { problem_set_problem.save! }
+        .to change { contest_score.reload.score }
+        .from(100)
+        .to(50)
+    end
+  end
+end


### PR DESCRIPTION
See commit messages for more useful description of what's happened here, but it's almost entirely spec changes.