### PR TITLE
Fix problem set item list overflow

### DIFF
--- a/app/views/problem_sets/_item.html.erb
+++ b/app/views/problem_sets/_item.html.erb
@@ -22,7 +22,7 @@
 </tr>
 <tr>
   <td colspan="<%= @colspan %>" style="padding: 0px;">
-    <div id="problemset<%= problem_set.id %>problems" style="display: none; overflow-y: hidden;">
+    <div id="problemset<%= problem_set.id %>problems" style="display: none; overflow-y: scroll;">
       <table class="main_table hoverable selectable" onClick="event.cancelBubble = true;">
         <tbody>
           <% problems.each do |problem| %>


### PR DESCRIPTION
Long problem names cause clipping in problemset item lists. Fixed by changing `overflow` from hidden to `scroll`.

<img width="768" alt="Screenshot 2025-06-30 at 3 37 47 PM" src="https://github.com/user-attachments/assets/708c81ec-7971-47de-a981-db3c560b619b" />
