### PR TITLE
Implement expanding row items in terms of aria-expanded & css

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -179,3 +179,8 @@ $(document).ready(function() {
 
   $("#main").focus();
 });
+
+function toggleVisibility(element) {
+  let prevValue = element.getAttribute("aria-expanded") === "true";
+  element.setAttribute("aria-expanded", !prevValue);
+}

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -343,3 +343,14 @@ input[type="file"] {
 .countdown.large {
   font-size: 36px;
 }
+
+tr[aria-expanded].subheading + tr > td > div {
+  overflow-y: hidden;
+  max-height: 1000px;
+  transition: max-height 0.3s cubic-bezier(1,0,1,0);
+}
+
+tr[aria-expanded="false"].subheading + tr > td > div {
+  max-height: 0px;
+  transition: max-height 0.3s cubic-bezier(0,1,0,1);
+}

--- a/app/views/problem_sets/_item.html.erb
+++ b/app/views/problem_sets/_item.html.erb
@@ -3,8 +3,8 @@
 <% problems = problem_set.problems_with_scores_by_user(current_user.try(:id) || -1) %>
 <% weighted = problems.map{|p|p.weighting != 100}.any? %>
 <%# problems = problem_set.problems.score_by_user(current_user.id) %>
-<tr class="subheading">
-  <td onClick="toggle_height('<%= "problemset#{problem_set.id}problems" %>');"><%= defined?(name) ? name : problem_set.name %> <span style="font-weight: normal; font-style: italic;">(<%= problem_set.problems.length %> problem<%= problem_set.problems.length==1?"":"s" %>)</span></td>
+<tr class="subheading" aria-expanded="false" aria-controls="problemset<%= problem_set.id%>" onclick="toggleVisibility(this)">
+  <td><%= defined?(name) ? name : problem_set.name %> <span style="font-weight: normal; font-style: italic;">(<%= problem_set.problems.length %> problem<%= problem_set.problems.length==1?"":"s" %>)</span></td>
   <td>
     <% if problems.length > 0 %>
       <% set_score = problems.inject(0){|sum,x| sum+(x.weighted_score.to_i||0)} %>
@@ -20,9 +20,9 @@
     <td><%= link_to 'Destroy', problem_set, :data => { :confirm => 'Are you sure?' }, :method => :delete if policy(problem_set).destroy? %></td>
   <% end %>
 </tr>
-<tr>
+<tr id="problemset<%=problem_set.id%>">
   <td colspan="<%= @colspan %>" style="padding: 0px;">
-    <div id="problemset<%= problem_set.id %>problems" style="display: none; overflow-y: hidden;">
+    <div id="problemset<%= problem_set.id %>problems">
       <table class="main_table hoverable selectable" onClick="event.cancelBubble = true;">
         <tbody>
           <% problems.each do |problem| %>


### PR DESCRIPTION
Instead of relying on jQuery doing fancy things with the hide and show,
we can just use a css-transition. Unfortunately, css-transitions don't
really support animating max-height very nicely between 0 and auto, so
instead we animate between a 0 and a number larger than our biggest
problem set.

We use a cubic-bezier() animation so we can cheekily invert the
animation curve between the two states, leading to a nicer closing
experience when the content itself is larger than the max-height.

Using aria-expanded gives us a very slightly nicer experience on
screen-readers
