### PR TITLE
Remove config option raise_in_transaction_callbacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,9 +25,6 @@ module NZTrain
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
-
     # JavaScript files you want as :defaults (application.js is always included).
     # config.action_view.javascript_expansions[:defaults] = %w(jquery rails)
 


### PR DESCRIPTION
This is now default in Rails 5.0, so we no longer need this opt-in
config option.

https://guides.rubyonrails.org/v6.1.0/5_0_release_notes.html#active-record-notable-changes