### PR TITLE
Remove some unused(?!) methods on contest_relation

### DIFF
--- a/app/models/contest_relation.rb
+++ b/app/models/contest_relation.rb
@@ -67,16 +67,11 @@ class ContestRelation < ActiveRecord::Base
     update_finish_at
   end
 
-  def contest_with_update=(contest)
-    self.contest_without_update = (contest)
-    update_finish_at
-  end
-
   def extra_time=(extra_time)
     self[:extra_time] = extra_time
     update_finish_at
   end
-  alias_method_chain :contest=, :update
+
   def update_finish_at
     self.finish_at = [contest.end_time, started_at.advance(hours: contest.duration.to_f)].min.advance(seconds: extra_time) unless contest.nil? || started_at.nil?
   end


### PR DESCRIPTION
alias_method_chain is deprecated in Rails 5.0 and removed in Rails 5.1,
so we need to stop using it. I can't find any way these are being
called, unless it ends up being ActiveRecord implict nonsense I can't
find evidence of.