### PR TITLE
Remove serve_static_files and enable public_file_server from config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,6 +13,13 @@ NZTrain::Application.configure do
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
+  # Disable serving static files from the `/public` folder by folder since
+  # Apache or NGINX already handles this.
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # true so Webrick testing of production mode works
+  config.public_file_server.enabled = true
+
   # Specifies the header that your server uses for sending files
   # config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
@@ -30,10 +37,6 @@ NZTrain::Application.configure do
 
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store
-
-  # Disable Rails's static asset server
-  # In production, Apache or nginx will already do this
-  config.serve_static_files = true # true so Webrick testing of production mode works
 
   # Enable serving of images, stylesheets, and javascripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,12 @@ NZTrain::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
+  # Configure public file server for tests with Cache-Control for performance.
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=3600'
+  }
+
   # Show full error reports and disable caching
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
@@ -34,10 +40,6 @@ NZTrain::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
-
-  # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_files = true
-  config.static_cache_control = "public, max-age=3600"
 
   # Raise exception on mass assignment protection for Active Record models
   # config.active_record.mass_assignment_sanitizer = :strict # Can't do this yet


### PR DESCRIPTION
config.public_file_server was added in like Rails 3, and
serve_static_files is deprecated in 5.0 and removed in 5.1.

The relocations are to have these files match up more with the default
generated files by Rails.