### PR TITLE
Replace kwargs request specs with params objects

### DIFF
--- a/spec/controllers/accounts/passwords_controller_spec.rb
+++ b/spec/controllers/accounts/passwords_controller_spec.rb
@@ -10,7 +10,7 @@ describe Accounts::PasswordsController do
     end
 
     it "can send password reset email" do
-      post :create, user: {email: user.email}
+      post :create, parans: { user: {email: user.email} }
 
       expect(mail = ActionMailer::Base.deliveries.last).to_not be_nil
 
@@ -25,12 +25,12 @@ describe Accounts::PasswordsController do
     end
 
     it "can edit password" do
-      get :edit, reset_password_token: @token
+      get :edit, params: { reset_password_token: @token }
       expect(response).to be_success
     end
 
     it "can update password" do
-      post :update, user: {reset_password_token: @token, password: "newpassword", password_confirmation: "newpassword"}
+      post :update, params: { user: {reset_password_token: @token, password: "newpassword", password_confirmation: "newpassword"} }
 
       expect(user.reload.valid_password?("newpassword")).to be true
     end

--- a/spec/controllers/accounts/registrations_controller_spec.rb
+++ b/spec/controllers/accounts/registrations_controller_spec.rb
@@ -8,7 +8,7 @@ describe Accounts::RegistrationsController do
 
   it "can signup (create action)" do
     expect do
-      post :create, user: {username: "signup_username", name: "Mr. SignUp", email: "signup@nztrain.com", password: "password", password_confirmation: "password"}
+      post :create, params: { user: {username: "signup_username", name: "Mr. SignUp", email: "signup@nztrain.com", password: "password", password_confirmation: "password"} }
     end.to change { User.count }.by(1)
     # check signup attributes saved
     newuser = User.find_by_username("signup_username")
@@ -34,12 +34,12 @@ describe Accounts::RegistrationsController do
     end
 
     it "can get edit password form" do
-      get :edit, type: "password"
+      get :edit, params: { type: "password" }
       expect(response).to be_success
     end
 
     it "can get edit email form" do
-      get :edit, type: "email"
+      get :edit, params: { type: "email" }
       expect(response).to be_success
     end
   end

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -32,14 +32,14 @@ describe ProblemsController do
     include_examples "for any user"
 
     it "can get submit for group problem" do
-      get :submit, id: group_problem.id
+      get :submit, params: { id: group_problem.id }
       expect(response).to be_success
     end
 
     it "can post submit for group problem" do
       expect_any_instance_of(Submission).to receive(:judge)
       # post multi-part form
-      post :submit, id: group_problem.id, submission: {language_id: LanguageGroup.find_by_identifier("c++").current_language.id, source_file: fixture_file_upload("/files/adding.cpp", "text/plain")}
+      post :submit, params: { id: group_problem.id, submission: {language_id: LanguageGroup.find_by_identifier("c++").current_language.id, source_file: fixture_file_upload("/files/adding.cpp", "text/plain")} }
       expect(response).to redirect_to submission_path(assigns(:submission))
       expect(assigns(:submission).problem_id).to eq(group_problem.id)
       expect(assigns(:submission).user_id).to eq(user.id)

--- a/spec/support/controllers_spec_helper.rb
+++ b/spec/support/controllers_spec_helper.rb
@@ -51,7 +51,7 @@ module ControllersSpecHelper
     def can_index resource, options = {}
       options = process_plural_options resource, {action: :index}.merge(options)
       it "can #{options[:action]} #{resource}" do
-        get options[:action], (process_hash options[:params])
+        get options[:action], params: process_hash(options[:params])
         expect(response).to be_success
         collection = assigns(options[:resources_name])
         expect(collection.is_a?(ActiveRecord::Relation) || collection.is_a?(Array)).to be true
@@ -73,7 +73,7 @@ module ControllersSpecHelper
 
       it "can show #{resource}" do
         object = subject_object(resource)
-        get :show, id: object.to_param
+        get :show, params: { id: object.to_param }
         expect(response).to be_success
       end
     end
@@ -83,14 +83,14 @@ module ControllersSpecHelper
 
       it "can edit #{resource}" do
         object = subject_object(resource)
-        get :edit, id: object.to_param
+        get :edit, params: { id: object.to_param }
         expect(response).to be_success
         assigns(options[:resource_name]).instance_of?(object.class)
       end
 
       it "can update #{resource}" do
         object = subject_object(resource)
-        put :update, :id => object.to_param, options[:resource_name] => object.attributes.symbolize_keys.merge(options[:attributes])
+        put :update, params: { :id => object.to_param, options[:resource_name] => object.attributes.symbolize_keys.merge(options[:attributes]) }
         expect(response).to redirect_to send "#{options[:resource_name]}_path", assigns(options[:resource_name])
         expect(assigns(options[:resource_name])).to have_attributes(options[:attributes])
       end
@@ -106,7 +106,7 @@ module ControllersSpecHelper
 
       it "can create #{resource}" do
         expect do
-          post :create, options[:resource_name] => options[:attributes]
+          post :create, params: { options[:resource_name] => options[:attributes] }
         end.to change { (Kernel.const_get options[:class_name]).count }.by(1)
         expect(response).to redirect_to send "#{options[:resource_name]}_path", assigns(options[:resource_name])
         expect(assigns(options[:resource_name])).to have_attributes(options[:attributes])
@@ -119,7 +119,7 @@ module ControllersSpecHelper
       it "can destroy #{resource}" do
         object = subject_object(resource)
         expect do
-          delete :destroy, id: object.to_param
+          delete :destroy, params: { id: object.to_param }
         end.to change { object.class.count }
            .by(-1)
         expect(response).to be_redirect


### PR DESCRIPTION
Deprecated in Rails 5, removed in 5.1.