### PR TITLE
Replace usages of deprecated "uniq" with "distinct"

### DIFF
--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -15,7 +15,7 @@ class Contest < ActiveRecord::Base
 
   has_many :group_associations, class_name: GroupContest, inverse_of: :contest, dependent: :destroy
   has_many :groups, through: :group_associations
-  has_many :group_members, -> { uniq }, through: :groups, source: :users
+  has_many :group_members, -> { distinct }, through: :groups, source: :users
 
   belongs_to :owner, class_name: :User
 

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -18,7 +18,7 @@ class Problem < ActiveRecord::Base
 
   has_many :contests, through: :problem_sets
   has_many :contest_relations, through: :contests
-  has_many :groups, -> { uniq }, through: :problem_sets
+  has_many :groups, -> { distinct }, through: :problem_sets
   has_many :group_memberships, through: :groups, source: :memberships
 
   has_many :filelinks, -> { includes(:file_attachment) }, as: :root, dependent: :destroy

--- a/app/models/problem_set.rb
+++ b/app/models/problem_set.rb
@@ -5,7 +5,7 @@ class ProblemSet < ActiveRecord::Base
   has_many :problems, through: :problem_associations
   has_many :group_associations, class_name: GroupProblemSet, inverse_of: :problem_set, dependent: :destroy
   has_many :groups, through: :group_associations
-  has_many :group_memberships, -> { uniq }, through: :groups, source: :memberships
+  has_many :group_memberships, -> { distinct }, through: :groups, source: :memberships
 
   has_many :contests
   has_many :contest_relations, through: :contests, source: :contest_relations


### PR DESCRIPTION
Deprecated in Rails 5, removed in Rails 5.1