### PR TITLE
Enable Sentry APM

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,4 +4,6 @@ Sentry.init do |config|
     dsn = Setting.find_by_key("sentry_dsn")&.value
     config.dsn = dsn if dsn.present?
   end
+
+  config.traces_sample_rate = 1.0
 end


### PR DESCRIPTION
This may be too high, but our free Sentry plan includes like 1 billion
traces which is a totally bananas number. It's easy to tune, and Sentry
won't bill us if it goes over, it'll just stop accepting new traces.