### PR TITLE
Update Bundler install script to use Bundler 1.17

### DIFF
--- a/script/install/bundler.bash
+++ b/script/install/bundler.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-bundler_version="~>1.16" # must be < 2.0 because Rails 4.0.13 requires Bundler < 2.0
+bundler_version="~>1.17" # must be < 2.0 because Rails 4.0.13 requires Bundler < 2.0
 
 bundle version 2>/dev/null || {
   # check if directory where gems are installed is writable


### PR DESCRIPTION
Gemfile.lock recently changed to say "BUNDLED WITH 1.17.3", so now Bundler 1.16 gives a warning.