### PR TITLE
Change qless log level to INFO

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,6 @@ namespace :qless do
     queues = %w[judge queue stalejudge importer].map { |name| $qless.queues[name] }
     job_reserver = Qless::JobReservers::Ordered.new(queues)
 
-    worker = Qless::Workers::ForkingWorker.new(job_reserver, num_workers: 2, interval: 2).run
+    worker = Qless::Workers::ForkingWorker.new(job_reserver, num_workers: 2, interval: 2, log_level: Logger::INFO).run
   end
 end


### PR DESCRIPTION
Was previously using the default (WARN). INFO seems to just adds logs for whenever a submission is judged and whenever a worker is spawned, so it shouldn't be too spammy.