### PR TITLE
Remove J

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -58,7 +58,7 @@ class Language < ApplicationRecord
 
   # for the selection dropdown
   def self.grouped_submission_options
-    current = ["c++", "c", "python", "csharp", "java", "javascript", "haskell", "ruby", "j"] # language group identifiers, order is preserved
+    current = ["c++", "c", "python", "csharp", "java", "javascript", "haskell", "ruby"] # language group identifiers, order is preserved
     other = ["c++14", "c99", "pypy3"] # language identifiers, ordered by language name
     current_langs = LanguageGroup.where(identifier: current).preload(:current_language).map(&:current_language)
     current_options = current_langs.sort_by { |lang| current.index(lang.group.identifier) }.map { |lang| [lang.name, lang.id] }

--- a/app/services/isolate.rb
+++ b/app/services/isolate.rb
@@ -241,7 +241,6 @@ EOF
       "opt" => [], # for ghc from ppa:hvr/ghc
       "etc" => []
       # 'etc/alternatives' => [], # required for many symbolic links to work
-      # 'etc/j' => [], # required for J to work (load profile)
     }.map do |dir, opt|
       fullpath = File.expand_path(dir, isolate_root)
       boxpath = File.expand_path(dir, "/")

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -133,21 +133,6 @@ ruby:
       name: "Ruby 2.2"
       interpreter: /usr/bin/ruby2.2
 
-j:
-  name: J
-  lexer: text
-  compiled: no
-  interpreted: yes
-  current: j8
-  extension: .ijs
-  source_filename: program
-  processes: 3 # needed for system/main/stdlib.ijs to shell out to uname
-  interpreter_command: "%{interpreter} %{source}"
-  variants:
-    j8:
-      name: "J 8.03"
-      interpreter: /usr/bin/ijconsole-8.0.3
-
 javascript:
   name: JavaScript
   lexer: javascript

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -147,36 +147,6 @@ chroot "$ISOLATE_ROOT" apt-get install ruby # Ruby (ruby)
   echo "$chroot_install ruby2.2"
   chroot "$ISOLATE_ROOT" apt-get install ruby2.2
 
-
-  # install J
-  bash script/confirm.bash 'Install J' && {
-    chroot "$ISOLATE_ROOT" mkdir /home/j -p
-    J_TAG="J803"
-    J_DEB="j803_amd64.deb"
-    J_SAVE="/home/j/$J_DEB"
-    [ -f "$ISOLATE_ROOT/$J_SAVE" ] || {
-      echo "wget -O \"$ISOLATE_ROOT/$J_SAVE\" https://github.com/NZOI/J-install/releases/download/$J_TAG/$J_DEB"
-      wget -O "$ISOLATE_ROOT/$J_SAVE" "https://github.com/NZOI/J-install/releases/download/$J_TAG/$J_DEB"
-    }
-
-    echo "$chroot_cmd dpkg -i $J_SAVE"
-    chroot "$ISOLATE_ROOT" dpkg -i "$J_SAVE"
-
-    cat << EOF > "$ISOLATE_ROOT"/home/j/install.ijs
-load 'pacman'
-'update' jpkg ''
-'install' jpkg 'format/printf'
-'install' jpkg 'format/datefmt'
-'install' jpkg 'types/datetime'
-'upgrade' jpkg 'all'
-exit 0
-EOF
-
-    echo "$chroot_cmd ijconsole /home/j/install.ijs"
-    chroot "$ISOLATE_ROOT" ijconsole /home/j/install.ijs
-  }
-  # end install J
-
 }
 
 if [ ! -f "$ISOLATE_ROOT/usr/bin/cint.rb" ] ; then


### PR DESCRIPTION
It fails to install on Ubuntu 24.04, and no one uses it so it's probably not worth trying to fix.

```
$ chroot "/srv/chroot/nztrain" ijconsole /home/j/install.ijs
ijconsole: error while loading shared libraries: libreadline.so.6: cannot open shared object file: No such file or directory
```

See branch [`ubuntu-noble`](https://github.com/NZOI/nztrain/commits/ubuntu-noble/) for other changes to get nztrain running on Ubuntu 24.04.