### PR TITLE
Adjust default controller_spec_helper params to never be nil

### DIFF
--- a/spec/support/controllers_spec_helper.rb
+++ b/spec/support/controllers_spec_helper.rb
@@ -14,7 +14,7 @@ module ControllersSpecHelper
         hash[key] = process_hash value
       end
     end
-    hash
+    hash || {}
   end
 
   def subject_object(resource)


### PR DESCRIPTION
Apparently something changes between Rails 5 and Rails 5.1 changes
(either Rails 5.1, or some of the test support libraries) but it
_really_ doesn't like getting nil as a value to params in request specs.
This just defaults it to an empty hash which works fine and passes all
the specs that were previously failing.