### PR TITLE
Convert remaining before_filter cases to before_action

### DIFF
--- a/app/controllers/accounts/requests_controller.rb
+++ b/app/controllers/accounts/requests_controller.rb
@@ -1,5 +1,5 @@
 class Accounts::RequestsController < ApplicationController
-  before_filter do
+  before_action do
     raise Pundit::NotAuthorizedError unless user_signed_in?
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,11 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
 
-  before_filter :update_last_seen_at
-  before_filter :update_contest_checkin
-  before_filter :read_settings
-  before_filter :check_su_loss
-  before_filter :configure_permitted_parameters, if: :devise_controller?
+  before_action :update_last_seen_at
+  before_action :update_contest_checkin
+  before_action :read_settings
+  before_action :check_su_loss
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   # helper ApplicationHelper
   # helper ProblemsHelper

--- a/app/controllers/contest_relations_controller.rb
+++ b/app/controllers/contest_relations_controller.rb
@@ -1,6 +1,6 @@
 class ContestRelationsController < ApplicationController
   before_action :authenticate_user!
-  before_filter :find_contest_relation
+  before_action :find_contest_relation
 
   def destroy
     authorize @contest_relation, :destroy?

--- a/app/controllers/groups/problem_sets_controller.rb
+++ b/app/controllers/groups/problem_sets_controller.rb
@@ -1,7 +1,7 @@
 class Groups::ProblemSetsController < ApplicationController
   layout "group"
 
-  before_filter do
+  before_action do
     @group = Group.find(params[:group_id])
   end
 

--- a/app/controllers/importers/problem_series_controller.rb
+++ b/app/controllers/importers/problem_series_controller.rb
@@ -1,5 +1,5 @@
 class Importers::ProblemSeriesController < ApplicationController
-  before_filter do
+  before_action do
     raise Pundit::NotAuthorizedError unless current_user.is_superadmin?
     raise ActiveRecord::RecordNotFound if importer.nil?
   end

--- a/app/controllers/problems/test_cases_controller.rb
+++ b/app/controllers/problems/test_cases_controller.rb
@@ -1,7 +1,7 @@
 class Problems::TestCasesController < ApplicationController
   layout "problem"
 
-  before_filter do
+  before_action do
     @problem = Problem.find(params[:problem_id])
   end
 


### PR DESCRIPTION
before_filter is deprecated, and removed in Rails 5.1