### PR TITLE
Add migration version to all prior db migrations

### DIFF
--- a/db/migrate/20110819224757_devise_create_users.rb
+++ b/db/migrate/20110819224757_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20110820005833_create_test_cases.rb
+++ b/db/migrate/20110820005833_create_test_cases.rb
@@ -1,4 +1,4 @@
-class CreateTestCases < ActiveRecord::Migration
+class CreateTestCases < ActiveRecord::Migration[4.2]
   def self.up
     create_table :test_cases do |t|
       t.text :input

--- a/db/migrate/20110820010205_create_problems.rb
+++ b/db/migrate/20110820010205_create_problems.rb
@@ -1,4 +1,4 @@
-class CreateProblems < ActiveRecord::Migration
+class CreateProblems < ActiveRecord::Migration[4.2]
   def self.up
     create_table :problems do |t|
       t.string :title, limit: 255

--- a/db/migrate/20110820013719_create_submissions.rb
+++ b/db/migrate/20110820013719_create_submissions.rb
@@ -1,4 +1,4 @@
-class CreateSubmissions < ActiveRecord::Migration
+class CreateSubmissions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :submissions do |t|
       t.text :source

--- a/db/migrate/20110904033519_create_contest_relations.rb
+++ b/db/migrate/20110904033519_create_contest_relations.rb
@@ -1,4 +1,4 @@
-class CreateContestRelations < ActiveRecord::Migration
+class CreateContestRelations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :contest_relations do |t|
       t.integer :user_id

--- a/db/migrate/20110904033742_create_contests.rb
+++ b/db/migrate/20110904033742_create_contests.rb
@@ -1,4 +1,4 @@
-class CreateContests < ActiveRecord::Migration
+class CreateContests < ActiveRecord::Migration[4.2]
   def self.up
     create_table :contests do |t|
       t.string :title, limit: 255

--- a/db/migrate/20110904045150_create_contests_problems_table.rb
+++ b/db/migrate/20110904045150_create_contests_problems_table.rb
@@ -1,4 +1,4 @@
-class CreateContestsProblemsTable < ActiveRecord::Migration
+class CreateContestsProblemsTable < ActiveRecord::Migration[4.2]
   def self.up
     create_table :contests_problems, id: false do |t|
       t.integer :contest_id

--- a/db/migrate/20110924030742_create_groups.rb
+++ b/db/migrate/20110924030742_create_groups.rb
@@ -1,4 +1,4 @@
-class CreateGroups < ActiveRecord::Migration
+class CreateGroups < ActiveRecord::Migration[4.2]
   def self.up
     create_table :groups do |t|
       t.string :name, limit: 255

--- a/db/migrate/20110924035337_create_group_user_table.rb
+++ b/db/migrate/20110924035337_create_group_user_table.rb
@@ -1,4 +1,4 @@
-class CreateGroupUserTable < ActiveRecord::Migration
+class CreateGroupUserTable < ActiveRecord::Migration[4.2]
   def self.up
     create_table :groups_users, id: false do |t|
       t.integer :group_id

--- a/db/migrate/20110925021620_create_group_problem_table.rb
+++ b/db/migrate/20110925021620_create_group_problem_table.rb
@@ -1,4 +1,4 @@
-class CreateGroupProblemTable < ActiveRecord::Migration
+class CreateGroupProblemTable < ActiveRecord::Migration[4.2]
   def self.up
     create_table :groups_problems, id: false do |t|
       t.integer :group_id

--- a/db/migrate/20111002021523_create_contest_group_table.rb
+++ b/db/migrate/20111002021523_create_contest_group_table.rb
@@ -1,4 +1,4 @@
-class CreateContestGroupTable < ActiveRecord::Migration
+class CreateContestGroupTable < ActiveRecord::Migration[4.2]
   def self.up
     create_table :contests_groups, id: false do |t|
       t.integer :contest_id

--- a/db/migrate/20111022023246_add_judge_output_to_submissions.rb
+++ b/db/migrate/20111022023246_add_judge_output_to_submissions.rb
@@ -1,4 +1,4 @@
-class AddJudgeOutputToSubmissions < ActiveRecord::Migration
+class AddJudgeOutputToSubmissions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :submissions, :judge_output, :text
   end

--- a/db/migrate/20111206102437_add_brownie_points_to_users.rb
+++ b/db/migrate/20111206102437_add_brownie_points_to_users.rb
@@ -1,4 +1,4 @@
-class AddBrowniePointsToUsers < ActiveRecord::Migration
+class AddBrowniePointsToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :brownie_points, :integer, default: 0
   end

--- a/db/migrate/20120109132817_add_evaluator_to_problem.rb
+++ b/db/migrate/20120109132817_add_evaluator_to_problem.rb
@@ -1,4 +1,4 @@
-class AddEvaluatorToProblem < ActiveRecord::Migration
+class AddEvaluatorToProblem < ActiveRecord::Migration[4.2]
   def self.up
     add_column :problems, :evaluator, :text
   end

--- a/db/migrate/20120111090946_add_name_to_user.rb
+++ b/db/migrate/20120111090946_add_name_to_user.rb
@@ -1,4 +1,4 @@
-class AddNameToUser < ActiveRecord::Migration
+class AddNameToUser < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :name, :string, limit: 255
   end

--- a/db/migrate/20120115015112_create_contests_max_score_submissions_view.rb
+++ b/db/migrate/20120115015112_create_contests_max_score_submissions_view.rb
@@ -1,4 +1,4 @@
-class CreateContestsMaxScoreSubmissionsView < ActiveRecord::Migration
+class CreateContestsMaxScoreSubmissionsView < ActiveRecord::Migration[4.2]
   def self.up
     case ActiveRecord::Base.connection.adapter_name
     when "SQLite"

--- a/db/migrate/20120115020222_create_contests_latest_submissions_view.rb
+++ b/db/migrate/20120115020222_create_contests_latest_submissions_view.rb
@@ -1,4 +1,4 @@
-class CreateContestsLatestSubmissionsView < ActiveRecord::Migration
+class CreateContestsLatestSubmissionsView < ActiveRecord::Migration[4.2]
   def self.up
     case ActiveRecord::Base.connection.adapter_name
     when "SQLite"

--- a/db/migrate/20120115044124_create_contests_max_score_scoreboard_view.rb
+++ b/db/migrate/20120115044124_create_contests_max_score_scoreboard_view.rb
@@ -1,4 +1,4 @@
-class CreateContestsMaxScoreScoreboardView < ActiveRecord::Migration
+class CreateContestsMaxScoreScoreboardView < ActiveRecord::Migration[4.2]
   def self.up
     case ActiveRecord::Base.connection.adapter_name
     when "SQLite"

--- a/db/migrate/20120115044140_create_contests_latest_scoreboard_view.rb
+++ b/db/migrate/20120115044140_create_contests_latest_scoreboard_view.rb
@@ -1,4 +1,4 @@
-class CreateContestsLatestScoreboardView < ActiveRecord::Migration
+class CreateContestsLatestScoreboardView < ActiveRecord::Migration[4.2]
   def self.up
     case ActiveRecord::Base.connection.adapter_name
     when "SQLite"

--- a/db/migrate/20120115050204_create_contests_count_submissions_view.rb
+++ b/db/migrate/20120115050204_create_contests_count_submissions_view.rb
@@ -1,4 +1,4 @@
-class CreateContestsCountSubmissionsView < ActiveRecord::Migration
+class CreateContestsCountSubmissionsView < ActiveRecord::Migration[4.2]
   def self.up
     execute "CREATE VIEW contests_count_submissions AS SELECT contest_relations.contest_id, submissions.user_id, submissions.problem_id, COUNT(*) AS count FROM contests JOIN contest_relations ON contests.id = contest_relations.contest_id JOIN contests_problems ON contests_problems.contest_id = contests.id JOIN submissions ON contest_relations.user_id = submissions.user_id AND submissions.problem_id = contests_problems.problem_id WHERE submissions.created_at BETWEEN contests.start_time AND contests.end_time GROUP BY contest_relations.contest_id, submissions.user_id, submissions.problem_id;"
   end

--- a/db/migrate/20120117133515_add_indexes_id_fields.rb
+++ b/db/migrate/20120117133515_add_indexes_id_fields.rb
@@ -1,4 +1,4 @@
-class AddIndexesIdFields < ActiveRecord::Migration
+class AddIndexesIdFields < ActiveRecord::Migration[4.2]
   # indexes designed to allow fast table joins, eg. when
   #   - getting users competing in a contest
   #   - getting the contests a user has competed in

--- a/db/migrate/20120119025544_create_problem_sets.rb
+++ b/db/migrate/20120119025544_create_problem_sets.rb
@@ -1,4 +1,4 @@
-class CreateProblemSets < ActiveRecord::Migration
+class CreateProblemSets < ActiveRecord::Migration[4.2]
   def self.up
     create_table :problem_sets do |t|
       t.string :title, limit: 255

--- a/db/migrate/20120119081526_remove_problems_contests_groups.rb
+++ b/db/migrate/20120119081526_remove_problems_contests_groups.rb
@@ -1,4 +1,4 @@
-class RemoveProblemsContestsGroups < ActiveRecord::Migration
+class RemoveProblemsContestsGroups < ActiveRecord::Migration[4.2]
   def self.up
     drop_table :contests_problems
     drop_table :groups_problems

--- a/db/migrate/20120122061329_create_roles.rb
+++ b/db/migrate/20120122061329_create_roles.rb
@@ -1,4 +1,4 @@
-class CreateRoles < ActiveRecord::Migration
+class CreateRoles < ActiveRecord::Migration[4.2]
   def self.up
     create_table :roles do |t|
       t.string :name, limit: 255

--- a/db/migrate/20120127063021_add_username_to_users.rb
+++ b/db/migrate/20120127063021_add_username_to_users.rb
@@ -1,4 +1,4 @@
-class AddUsernameToUsers < ActiveRecord::Migration
+class AddUsernameToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :username, :string, limit: 255
     add_column :users, :can_change_username, :boolean, default: true, null: false

--- a/db/migrate/20120128000525_create_settings.rb
+++ b/db/migrate/20120128000525_create_settings.rb
@@ -1,4 +1,4 @@
-class CreateSettings < ActiveRecord::Migration
+class CreateSettings < ActiveRecord::Migration[4.2]
   def self.up
     create_table :settings do |t|
       t.string :key, limit: 255

--- a/db/migrate/20120128235138_create_evaluators.rb
+++ b/db/migrate/20120128235138_create_evaluators.rb
@@ -1,4 +1,4 @@
-class CreateEvaluators < ActiveRecord::Migration
+class CreateEvaluators < ActiveRecord::Migration[4.2]
   def self.up
     create_table :evaluators do |t|
       t.string :name, limit: 255, unique: true, null: false

--- a/db/migrate/20120131100212_add_user_to_group.rb
+++ b/db/migrate/20120131100212_add_user_to_group.rb
@@ -1,4 +1,4 @@
-class AddUserToGroup < ActiveRecord::Migration
+class AddUserToGroup < ActiveRecord::Migration[4.2]
   def self.up
     add_column :groups, :user_id, :integer
     execute "UPDATE groups SET user_id = 35;"

--- a/db/migrate/20120201080849_add_title_index_to_problem.rb
+++ b/db/migrate/20120201080849_add_title_index_to_problem.rb
@@ -1,4 +1,4 @@
-class AddTitleIndexToProblem < ActiveRecord::Migration
+class AddTitleIndexToProblem < ActiveRecord::Migration[4.2]
   def self.up
     case ActiveRecord::Base.connection.adapter_name
     when "SQLite"

--- a/db/migrate/20120201113029_add_sessions_table.rb
+++ b/db/migrate/20120201113029_add_sessions_table.rb
@@ -1,4 +1,4 @@
-class AddSessionsTable < ActiveRecord::Migration
+class AddSessionsTable < ActiveRecord::Migration[4.2]
   def self.up
     create_table :sessions do |t|
       t.string :session_id, limit: 255, null: false

--- a/db/migrate/20120202100212_add_created_at_index_to_sessions.rb
+++ b/db/migrate/20120202100212_add_created_at_index_to_sessions.rb
@@ -1,4 +1,4 @@
-class AddCreatedAtIndexToSessions < ActiveRecord::Migration
+class AddCreatedAtIndexToSessions < ActiveRecord::Migration[4.2]
   def self.up
     add_index :sessions, :created_at
   end

--- a/db/migrate/20120208061444_add_avatar_to_user.rb
+++ b/db/migrate/20120208061444_add_avatar_to_user.rb
@@ -1,4 +1,4 @@
-class AddAvatarToUser < ActiveRecord::Migration
+class AddAvatarToUser < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :avatar, :string, limit: 255
   end

--- a/db/migrate/20120210235859_create_test_sets.rb
+++ b/db/migrate/20120210235859_create_test_sets.rb
@@ -1,4 +1,4 @@
-class CreateTestSets < ActiveRecord::Migration
+class CreateTestSets < ActiveRecord::Migration[4.2]
   def up
     create_table :test_sets do |t|
       t.integer :problem_id

--- a/db/migrate/20120610045635_add_debug_to_submission.rb
+++ b/db/migrate/20120610045635_add_debug_to_submission.rb
@@ -1,4 +1,4 @@
-class AddDebugToSubmission < ActiveRecord::Migration
+class AddDebugToSubmission < ActiveRecord::Migration[4.2]
   def change
     add_column :submissions, :debug_output, :text
   end

--- a/db/migrate/20120805020042_add_confirmable_to_users.rb
+++ b/db/migrate/20120805020042_add_confirmable_to_users.rb
@@ -1,4 +1,4 @@
-class AddConfirmableToUsers < ActiveRecord::Migration
+class AddConfirmableToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :confirmation_token, :string, limit: 255
     add_column :users, :confirmed_at, :datetime

--- a/db/migrate/20120805021508_make_existing_emails_unconfirmed_in_users.rb
+++ b/db/migrate/20120805021508_make_existing_emails_unconfirmed_in_users.rb
@@ -1,4 +1,4 @@
-class MakeExistingEmailsUnconfirmedInUsers < ActiveRecord::Migration
+class MakeExistingEmailsUnconfirmedInUsers < ActiveRecord::Migration[4.2]
   def up
     User.find_each do |user|
       if user[:unconfirmed_email].nil?

--- a/db/migrate/20120805105347_send_confirmation_instructions_to_all_users.rb
+++ b/db/migrate/20120805105347_send_confirmation_instructions_to_all_users.rb
@@ -1,4 +1,4 @@
-class SendConfirmationInstructionsToAllUsers < ActiveRecord::Migration
+class SendConfirmationInstructionsToAllUsers < ActiveRecord::Migration[4.2]
   def up
     User.find_each do |user| # for each user without confirmation instructions, send them
       user.send_confirmation_instructions if user.confirmation_sent_at.nil?

--- a/db/migrate/20120806025011_set_name_of_test_sets_and_test_cases.rb
+++ b/db/migrate/20120806025011_set_name_of_test_sets_and_test_cases.rb
@@ -1,4 +1,4 @@
-class SetNameOfTestSetsAndTestCases < ActiveRecord::Migration
+class SetNameOfTestSetsAndTestCases < ActiveRecord::Migration[4.2]
   def up
     # remove nulls from the name field
     TestSet.find_each do |set|

--- a/db/migrate/20120806212034_rename_user_to_owner.rb
+++ b/db/migrate/20120806212034_rename_user_to_owner.rb
@@ -1,4 +1,4 @@
-class RenameUserToOwner < ActiveRecord::Migration
+class RenameUserToOwner < ActiveRecord::Migration[4.2]
   def change
     rename_column :contests, :user_id, :owner_id
     rename_column :evaluators, :user_id, :owner_id

--- a/db/migrate/20120807033035_add_end_time_to_contest_relations.rb
+++ b/db/migrate/20120807033035_add_end_time_to_contest_relations.rb
@@ -1,4 +1,4 @@
-class AddEndTimeToContestRelations < ActiveRecord::Migration
+class AddEndTimeToContestRelations < ActiveRecord::Migration[4.2]
   def change
     add_column :contest_relations, :finish_at, :datetime # will be updated by caching
     Contest.find_each do |contest|

--- a/db/migrate/20120807042326_create_contest_scores.rb
+++ b/db/migrate/20120807042326_create_contest_scores.rb
@@ -1,4 +1,4 @@
-class CreateContestScores < ActiveRecord::Migration
+class CreateContestScores < ActiveRecord::Migration[4.2]
   def up
     # table to cache submission score for each problem/user (of all submissions that have been created)
     # however, this score may differ from actual submission score if it gets rejudged after a contest has been sealed

--- a/db/migrate/20120810041325_add_results_final_to_contest.rb
+++ b/db/migrate/20120810041325_add_results_final_to_contest.rb
@@ -1,4 +1,4 @@
-class AddResultsFinalToContest < ActiveRecord::Migration
+class AddResultsFinalToContest < ActiveRecord::Migration[4.2]
   def up
     add_column :contests, :finalized_at, :datetime, default: nil
 

--- a/db/migrate/20130116092216_add_input_output_to_submissions.rb
+++ b/db/migrate/20130116092216_add_input_output_to_submissions.rb
@@ -1,4 +1,4 @@
-class AddInputOutputToSubmissions < ActiveRecord::Migration
+class AddInputOutputToSubmissions < ActiveRecord::Migration[4.2]
   def up
     add_column :submissions, :input, :string, limit: 255
     add_column :submissions, :output, :string, limit: 255

--- a/db/migrate/20130926021023_convert_groups_users_to_memberships.rb
+++ b/db/migrate/20130926021023_convert_groups_users_to_memberships.rb
@@ -1,4 +1,4 @@
-class ConvertGroupsUsersToMemberships < ActiveRecord::Migration
+class ConvertGroupsUsersToMemberships < ActiveRecord::Migration[4.2]
   def up
     rename_table :groups_users, :memberships
     add_column :memberships, :id, :primary_key

--- a/db/migrate/20130926065258_add_visibility_and_membership_to_groups.rb
+++ b/db/migrate/20130926065258_add_visibility_and_membership_to_groups.rb
@@ -1,4 +1,4 @@
-class AddVisibilityAndMembershipToGroups < ActiveRecord::Migration
+class AddVisibilityAndMembershipToGroups < ActiveRecord::Migration[4.2]
   def change
     add_column :groups, :visibility, :integer, null: false, default: 0
     add_column :groups, :membership, :integer, null: false, default: 0

--- a/db/migrate/20130926080926_change_membership_table_name.rb
+++ b/db/migrate/20130926080926_change_membership_table_name.rb
@@ -1,4 +1,4 @@
-class ChangeMembershipTableName < ActiveRecord::Migration
+class ChangeMembershipTableName < ActiveRecord::Migration[4.2]
   def change
     rename_table :memberships, :group_memberships
   end

--- a/db/migrate/20130926105411_create_requests.rb
+++ b/db/migrate/20130926105411_create_requests.rb
@@ -1,4 +1,4 @@
-class CreateRequests < ActiveRecord::Migration
+class CreateRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :requests do |t|
       t.references :requester

--- a/db/migrate/20130928133936_add_last_seen_at_to_users.rb
+++ b/db/migrate/20130928133936_add_last_seen_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddLastSeenAtToUsers < ActiveRecord::Migration
+class AddLastSeenAtToUsers < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :last_seen_at, :timestamp
 

--- a/db/migrate/20131001082750_add_created_at_to_group_memberships.rb
+++ b/db/migrate/20131001082750_add_created_at_to_group_memberships.rb
@@ -1,4 +1,4 @@
-class AddCreatedAtToGroupMemberships < ActiveRecord::Migration
+class AddCreatedAtToGroupMemberships < ActiveRecord::Migration[4.2]
   def up
     add_column :group_memberships, :created_at, :timestamp
 

--- a/db/migrate/20131001083843_create_file_attachments.rb
+++ b/db/migrate/20131001083843_create_file_attachments.rb
@@ -1,4 +1,4 @@
-class CreateFileAttachments < ActiveRecord::Migration
+class CreateFileAttachments < ActiveRecord::Migration[4.2]
   def change
     create_table :file_attachments do |t|
       t.string :name, limit: 255

--- a/db/migrate/20131002083519_add_filepath_to_group_file_attachments.rb
+++ b/db/migrate/20131002083519_add_filepath_to_group_file_attachments.rb
@@ -1,4 +1,4 @@
-class AddFilepathToGroupFileAttachments < ActiveRecord::Migration
+class AddFilepathToGroupFileAttachments < ActiveRecord::Migration[4.2]
   def change
     add_column :group_file_attachments, :filepath, :string, limit: 255
 

--- a/db/migrate/20131007002316_create_test_case_relations.rb
+++ b/db/migrate/20131007002316_create_test_case_relations.rb
@@ -1,4 +1,4 @@
-class CreateTestCaseRelations < ActiveRecord::Migration
+class CreateTestCaseRelations < ActiveRecord::Migration[4.2]
   def change
     create_table :test_case_relations do |t|
       t.integer :test_case_id

--- a/db/migrate/20131007025034_convert_test_case_associations.rb
+++ b/db/migrate/20131007025034_convert_test_case_associations.rb
@@ -1,4 +1,4 @@
-class ConvertTestCaseAssociations < ActiveRecord::Migration
+class ConvertTestCaseAssociations < ActiveRecord::Migration[4.2]
   def up
     execute "INSERT INTO test_case_relations (test_set_id, test_case_id, created_at, updated_at) (SELECT test_set_id, id, created_at, updated_at FROM test_cases);"
 

--- a/db/migrate/20131013045616_create_languages.rb
+++ b/db/migrate/20131013045616_create_languages.rb
@@ -1,4 +1,4 @@
-class CreateLanguages < ActiveRecord::Migration
+class CreateLanguages < ActiveRecord::Migration[4.2]
   def change
     create_table :languages do |t|
       t.string :name, limit: 255

--- a/db/migrate/20131013050536_add_language_id_to_submission.rb
+++ b/db/migrate/20131013050536_add_language_id_to_submission.rb
@@ -1,4 +1,4 @@
-class AddLanguageIdToSubmission < ActiveRecord::Migration
+class AddLanguageIdToSubmission < ActiveRecord::Migration[4.2]
   def up
     add_column :submissions, :language_id, :integer
     rename_column :submissions, :language, :old_language

--- a/db/migrate/20131112032835_change_languages.rb
+++ b/db/migrate/20131112032835_change_languages.rb
@@ -1,4 +1,4 @@
-class ChangeLanguages < ActiveRecord::Migration
+class ChangeLanguages < ActiveRecord::Migration[4.2]
   def change
     rename_column :languages, :is_interpreted, :interpreted
     add_column :languages, :flags, :string, limit: 255

--- a/db/migrate/20131117055333_add_extension_to_language.rb
+++ b/db/migrate/20131117055333_add_extension_to_language.rb
@@ -1,4 +1,4 @@
-class AddExtensionToLanguage < ActiveRecord::Migration
+class AddExtensionToLanguage < ActiveRecord::Migration[4.2]
   def change
     add_column :languages, :extension, :string, limit: 255
   end

--- a/db/migrate/20131123054446_add_new_judge_columns_to_submissions.rb
+++ b/db/migrate/20131123054446_add_new_judge_columns_to_submissions.rb
@@ -1,4 +1,4 @@
-class AddNewJudgeColumnsToSubmissions < ActiveRecord::Migration
+class AddNewJudgeColumnsToSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_column :submissions, :judge_log, :text
     add_column :submissions, :isolate_score, :integer

--- a/db/migrate/20131130104622_add_indexes_to_test_case_relations.rb
+++ b/db/migrate/20131130104622_add_indexes_to_test_case_relations.rb
@@ -1,4 +1,4 @@
-class AddIndexesToTestCaseRelations < ActiveRecord::Migration
+class AddIndexesToTestCaseRelations < ActiveRecord::Migration[4.2]
   def change
     add_index :test_case_relations, :test_case_id
     add_index :test_case_relations, :test_set_id

--- a/db/migrate/20131201203759_isolate_judge_to_main_score_field.rb
+++ b/db/migrate/20131201203759_isolate_judge_to_main_score_field.rb
@@ -1,4 +1,4 @@
-class IsolateJudgeToMainScoreField < ActiveRecord::Migration
+class IsolateJudgeToMainScoreField < ActiveRecord::Migration[4.2]
   def up
     execute "UPDATE submissions SET score = isolate_score;"
 

--- a/db/migrate/20131205080753_add_job_to_submissions.rb
+++ b/db/migrate/20131205080753_add_job_to_submissions.rb
@@ -1,4 +1,4 @@
-class AddJobToSubmissions < ActiveRecord::Migration
+class AddJobToSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_column :submissions, :job, :string, limit: 255
   end

--- a/db/migrate/20131205201359_add_type_to_test_set.rb
+++ b/db/migrate/20131205201359_add_type_to_test_set.rb
@@ -1,4 +1,4 @@
-class AddTypeToTestSet < ActiveRecord::Migration
+class AddTypeToTestSet < ActiveRecord::Migration[4.2]
   def up
     add_column :test_sets, :visibility, :integer, limit: 1, null: false, default: 2
     add_column :test_cases, :problem_id, :integer

--- a/db/migrate/20131206074948_name_all_test_sets_and_cases.rb
+++ b/db/migrate/20131206074948_name_all_test_sets_and_cases.rb
@@ -1,6 +1,6 @@
 require "set"
 
-class NameAllTestSetsAndCases < ActiveRecord::Migration
+class NameAllTestSetsAndCases < ActiveRecord::Migration[4.2]
   def up
     Problem.find_each do |problem|
       name_uniquely(problem.test_sets)

--- a/db/migrate/20131207080120_change_enumeration_on_test_sets.rb
+++ b/db/migrate/20131207080120_change_enumeration_on_test_sets.rb
@@ -1,4 +1,4 @@
-class ChangeEnumerationOnTestSets < ActiveRecord::Migration
+class ChangeEnumerationOnTestSets < ActiveRecord::Migration[4.2]
   def up
     change_column :test_sets, :visibility, :integer, limit: 1, default: 0
     execute "UPDATE test_sets SET visibility = 3 WHERE visibility = 0" # sample

--- a/db/migrate/20131207091535_convert_dummy_test_sets_to_samples.rb
+++ b/db/migrate/20131207091535_convert_dummy_test_sets_to_samples.rb
@@ -1,4 +1,4 @@
-class ConvertDummyTestSetsToSamples < ActiveRecord::Migration
+class ConvertDummyTestSetsToSamples < ActiveRecord::Migration[4.2]
   def up
     # mainly for the COCI problems
     TestSet.where("name LIKE '%dummy%'").find_each do |set|

--- a/db/migrate/20131208014408_add_language_group_model.rb
+++ b/db/migrate/20131208014408_add_language_group_model.rb
@@ -1,4 +1,4 @@
-class AddLanguageGroupModel < ActiveRecord::Migration
+class AddLanguageGroupModel < ActiveRecord::Migration[4.2]
   def change
     create_table :language_groups do |t|
       t.string :identifier, limit: 255

--- a/db/migrate/20131208015044_change_language_identifiers_to_match.rb
+++ b/db/migrate/20131208015044_change_language_identifiers_to_match.rb
@@ -1,4 +1,4 @@
-class ChangeLanguageIdentifiersToMatch < ActiveRecord::Migration
+class ChangeLanguageIdentifiersToMatch < ActiveRecord::Migration[4.2]
   def mapping
     {"C++" => "c++03", "C" => "c99", "Python" => "python2", "Haskell" => "haskell2010"}
   end

--- a/db/migrate/20131208131723_rename_bad_usernames.rb
+++ b/db/migrate/20131208131723_rename_bad_usernames.rb
@@ -1,4 +1,4 @@
-class RenameBadUsernames < ActiveRecord::Migration
+class RenameBadUsernames < ActiveRecord::Migration[4.2]
   def up
     User.find_each do |user|
       if !user.save # bad username

--- a/db/migrate/20131209063832_fix_bad_markdown.rb
+++ b/db/migrate/20131209063832_fix_bad_markdown.rb
@@ -1,4 +1,4 @@
-class FixBadMarkdown < ActiveRecord::Migration
+class FixBadMarkdown < ActiveRecord::Migration[4.2]
   def fix_titles(string)
     toplevel = 10
     pos = 0

--- a/db/migrate/20131217112526_change_test_set_and_test_case_sample_and_prerequisites.rb
+++ b/db/migrate/20131217112526_change_test_set_and_test_case_sample_and_prerequisites.rb
@@ -1,4 +1,4 @@
-class ChangeTestSetAndTestCaseSampleAndPrerequisites < ActiveRecord::Migration
+class ChangeTestSetAndTestCaseSampleAndPrerequisites < ActiveRecord::Migration[4.2]
   def up
     add_column :test_sets, :prerequisite, :boolean, default: false
     add_column :test_cases, :sample, :boolean, default: false

--- a/db/migrate/20131219035927_add_problems_order_position_to_tests.rb
+++ b/db/migrate/20131219035927_add_problems_order_position_to_tests.rb
@@ -1,4 +1,4 @@
-class AddProblemsOrderPositionToTests < ActiveRecord::Migration
+class AddProblemsOrderPositionToTests < ActiveRecord::Migration[4.2]
   def up
     add_column :test_cases, :problem_order, :integer
     add_column :test_sets, :problem_order, :integer

--- a/db/migrate/20131219083253_make_attachments_polymorphic.rb
+++ b/db/migrate/20131219083253_make_attachments_polymorphic.rb
@@ -1,4 +1,4 @@
-class MakeAttachmentsPolymorphic < ActiveRecord::Migration
+class MakeAttachmentsPolymorphic < ActiveRecord::Migration[4.2]
   def up
     rename_table :group_file_attachments, :filelinks
     rename_column :filelinks, :group_id, :root_id

--- a/db/migrate/20131220034551_change_habtm_problem_associations.rb
+++ b/db/migrate/20131220034551_change_habtm_problem_associations.rb
@@ -1,4 +1,4 @@
-class ChangeHabtmProblemAssociations < ActiveRecord::Migration
+class ChangeHabtmProblemAssociations < ActiveRecord::Migration[4.2]
   def up
     #############################
     # problem sets <=> problems #

--- a/db/migrate/20131221014009_create_user_problem_relation.rb
+++ b/db/migrate/20131221014009_create_user_problem_relation.rb
@@ -1,4 +1,4 @@
-class CreateUserProblemRelation < ActiveRecord::Migration
+class CreateUserProblemRelation < ActiveRecord::Migration[4.2]
   def change
     reversible do |dir|
       dir.up do

--- a/db/migrate/20131221101354_remove_submission_classification_default.rb
+++ b/db/migrate/20131221101354_remove_submission_classification_default.rb
@@ -1,4 +1,4 @@
-class RemoveSubmissionClassificationDefault < ActiveRecord::Migration
+class RemoveSubmissionClassificationDefault < ActiveRecord::Migration[4.2]
   def up
     change_column :submissions, :classification, :integer, default: nil
   end

--- a/db/migrate/20131222021036_add_rejudge_at_to_problem.rb
+++ b/db/migrate/20131222021036_add_rejudge_at_to_problem.rb
@@ -1,4 +1,4 @@
-class AddRejudgeAtToProblem < ActiveRecord::Migration
+class AddRejudgeAtToProblem < ActiveRecord::Migration[4.2]
   def change
     add_column :problems, :rejudge_at, :timestamp
 

--- a/db/migrate/20131222110552_add_error_warnings_to_problem.rb
+++ b/db/migrate/20131222110552_add_error_warnings_to_problem.rb
@@ -1,4 +1,4 @@
-class AddErrorWarningsToProblem < ActiveRecord::Migration
+class AddErrorWarningsToProblem < ActiveRecord::Migration[4.2]
   def change
     add_column :problems, :test_error_count, :integer, default: 0
     add_column :problems, :test_warning_count, :integer, default: 0

--- a/db/migrate/20131224231543_add_visibility_to_filelinks.rb
+++ b/db/migrate/20131224231543_add_visibility_to_filelinks.rb
@@ -1,4 +1,4 @@
-class AddVisibilityToFilelinks < ActiveRecord::Migration
+class AddVisibilityToFilelinks < ActiveRecord::Migration[4.2]
   def change
     add_column :filelinks, :visibility, :integer, limit: 1, default: 0
   end

--- a/db/migrate/20131226232008_create_problem_series.rb
+++ b/db/migrate/20131226232008_create_problem_series.rb
@@ -1,4 +1,4 @@
-class CreateProblemSeries < ActiveRecord::Migration
+class CreateProblemSeries < ActiveRecord::Migration[4.2]
   def change
     create_table :problem_series do |t|
       t.string :name, limit: 255

--- a/db/migrate/20131226234044_add_index_to_problem_series.rb
+++ b/db/migrate/20131226234044_add_index_to_problem_series.rb
@@ -1,4 +1,4 @@
-class AddIndexToProblemSeries < ActiveRecord::Migration
+class AddIndexToProblemSeries < ActiveRecord::Migration[4.2]
   def change
     add_column :problem_series, :index_yaml, :text
   end

--- a/db/migrate/20140206025958_create_items_and_products.rb
+++ b/db/migrate/20140206025958_create_items_and_products.rb
@@ -1,4 +1,4 @@
-class CreateItemsAndProducts < ActiveRecord::Migration
+class CreateItemsAndProducts < ActiveRecord::Migration[4.2]
   def change
     create_table :entities do |t|
       t.string :name, limit: 255

--- a/db/migrate/20140215031939_add_holder_to_item.rb
+++ b/db/migrate/20140215031939_add_holder_to_item.rb
@@ -1,4 +1,4 @@
-class AddHolderToItem < ActiveRecord::Migration
+class AddHolderToItem < ActiveRecord::Migration[4.2]
   def change
     add_column :items, :holder_id, :integer
   end

--- a/db/migrate/20140215032346_change_product.rb
+++ b/db/migrate/20140215032346_change_product.rb
@@ -1,4 +1,4 @@
-class ChangeProduct < ActiveRecord::Migration
+class ChangeProduct < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :description, :text
     add_column :products, :image, :string, limit: 255

--- a/db/migrate/20140215033457_add_item_donator.rb
+++ b/db/migrate/20140215033457_add_item_donator.rb
@@ -1,4 +1,4 @@
-class AddItemDonator < ActiveRecord::Migration
+class AddItemDonator < ActiveRecord::Migration[4.2]
   def change
     add_column :items, :donator_id, :integer
   end

--- a/db/migrate/20140216002137_add_scan_token_to_items.rb
+++ b/db/migrate/20140216002137_add_scan_token_to_items.rb
@@ -1,4 +1,4 @@
-class AddScanTokenToItems < ActiveRecord::Migration
+class AddScanTokenToItems < ActiveRecord::Migration[4.2]
   def change
     add_column :items, :scan_token, :integer
   end

--- a/db/migrate/20140218212023_generate_scan_tokens.rb
+++ b/db/migrate/20140218212023_generate_scan_tokens.rb
@@ -1,4 +1,4 @@
-class GenerateScanTokens < ActiveRecord::Migration
+class GenerateScanTokens < ActiveRecord::Migration[4.2]
   def up
     Item.find_each do |item|
       if item[:scan_token].nil?

--- a/db/migrate/20141224080737_change_language_model.rb
+++ b/db/migrate/20141224080737_change_language_model.rb
@@ -1,4 +1,4 @@
-class ChangeLanguageModel < ActiveRecord::Migration
+class ChangeLanguageModel < ActiveRecord::Migration[4.2]
   def change
     add_column :languages, :source_filename, :string, limit: 255
     add_column :languages, :exe_extension, :string, limit: 255

--- a/db/migrate/20141224134542_clean_language_model.rb
+++ b/db/migrate/20141224134542_clean_language_model.rb
@@ -1,4 +1,4 @@
-class CleanLanguageModel < ActiveRecord::Migration
+class CleanLanguageModel < ActiveRecord::Migration[4.2]
   def change
     remove_column :languages, :flags, :string, limit: 255
     add_column :languages, :processes, :integer, default: 1

--- a/db/migrate/20150107090445_add_data_to_item_history.rb
+++ b/db/migrate/20150107090445_add_data_to_item_history.rb
@@ -1,4 +1,4 @@
-class AddDataToItemHistory < ActiveRecord::Migration
+class AddDataToItemHistory < ActiveRecord::Migration[4.2]
   def change
     add_column :item_histories, :data, :string, limit: 255
   end

--- a/db/migrate/20150107090450_add_timestamps_to_item_history.rb
+++ b/db/migrate/20150107090450_add_timestamps_to_item_history.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToItemHistory < ActiveRecord::Migration
+class AddTimestampsToItemHistory < ActiveRecord::Migration[4.2]
   def change
     add_column :item_histories, :acted_at, :datetime
     add_column :item_histories, :created_at, :datetime

--- a/db/migrate/20150109101859_add_school_country_year_to_users.rb
+++ b/db/migrate/20150109101859_add_school_country_year_to_users.rb
@@ -1,4 +1,4 @@
-class AddSchoolCountryYearToUsers < ActiveRecord::Migration
+class AddSchoolCountryYearToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :school_id, :integer
     add_column :users, :country_code, :string, limit: 3

--- a/db/migrate/20150116004052_nilize_empty_errors_and_warnings.rb
+++ b/db/migrate/20150116004052_nilize_empty_errors_and_warnings.rb
@@ -1,4 +1,4 @@
-class NilizeEmptyErrorsAndWarnings < ActiveRecord::Migration
+class NilizeEmptyErrorsAndWarnings < ActiveRecord::Migration[4.2]
   def up
     Submission.where.not(test_errors: nil, test_warnings: nil).find_each do |s|
       s.test_errors = nil if s.test_errors.nil? || s.test_errors.empty?

--- a/db/migrate/20150116010255_normalize_line_endings.rb
+++ b/db/migrate/20150116010255_normalize_line_endings.rb
@@ -1,4 +1,4 @@
-class NormalizeLineEndings < ActiveRecord::Migration
+class NormalizeLineEndings < ActiveRecord::Migration[4.2]
   def change
     TestCase.where("(input LIKE '%\r%') OR (output LIKE '%\r%')").find_each do |tc|
       tc.input = tc.input

--- a/db/migrate/20150117065146_create_schools.rb
+++ b/db/migrate/20150117065146_create_schools.rb
@@ -1,4 +1,4 @@
-class CreateSchools < ActiveRecord::Migration
+class CreateSchools < ActiveRecord::Migration[4.2]
   def change
     create_table :schools do |t|
       t.string :name, limit: 255

--- a/db/migrate/20150117073551_change_school_country_code.rb
+++ b/db/migrate/20150117073551_change_school_country_code.rb
@@ -1,4 +1,4 @@
-class ChangeSchoolCountryCode < ActiveRecord::Migration
+class ChangeSchoolCountryCode < ActiveRecord::Migration[4.2]
   def change
     rename_column :schools, :country, :country_code
 

--- a/db/migrate/20150118010607_weighted_contests.rb
+++ b/db/migrate/20150118010607_weighted_contests.rb
@@ -1,4 +1,4 @@
-class WeightedContests < ActiveRecord::Migration
+class WeightedContests < ActiveRecord::Migration[4.2]
   def change
     add_column :submissions, :evaluation, :float
     add_column :submissions, :points, :decimal

--- a/db/migrate/20150118104425_calculate_weighted_columns.rb
+++ b/db/migrate/20150118104425_calculate_weighted_columns.rb
@@ -1,6 +1,6 @@
 require "bigdecimal"
 
-class CalculateWeightedColumns < ActiveRecord::Migration
+class CalculateWeightedColumns < ActiveRecord::Migration[4.2]
   def up
     maxpoints = []
 

--- a/db/migrate/20150121113050_rename_weighting.rb
+++ b/db/migrate/20150121113050_rename_weighting.rb
@@ -1,4 +1,4 @@
-class RenameWeighting < ActiveRecord::Migration
+class RenameWeighting < ActiveRecord::Migration[4.2]
   def change
     rename_column :problem_set_problems, :points, :weighting
   end

--- a/db/migrate/20150124223718_add_options_to_contest.rb
+++ b/db/migrate/20150124223718_add_options_to_contest.rb
@@ -1,4 +1,4 @@
-class AddOptionsToContest < ActiveRecord::Migration
+class AddOptionsToContest < ActiveRecord::Migration[4.2]
   def change
     add_column :contests, :startcode, :string, limit: 255 # plain-text start-code
     add_column :contests, :observation, :integer, default: 1 # for observers: public (everyone), protected (groups it is added to even if not competing), private (only if competing)

--- a/db/migrate/20150204112552_cache_test_status_on_problem.rb
+++ b/db/migrate/20150204112552_cache_test_status_on_problem.rb
@@ -1,4 +1,4 @@
-class CacheTestStatusOnProblem < ActiveRecord::Migration
+class CacheTestStatusOnProblem < ActiveRecord::Migration[4.2]
   def change
     add_column :problems, :test_status, :integer, default: 0
   end

--- a/db/migrate/20150206053259_rename_country_id_to_code.rb
+++ b/db/migrate/20150206053259_rename_country_id_to_code.rb
@@ -1,4 +1,4 @@
-class RenameCountryIdToCode < ActiveRecord::Migration
+class RenameCountryIdToCode < ActiveRecord::Migration[4.2]
   def change
     remove_column :contest_relations, :country_id, :integer
     add_column :contest_relations, :country_code, :string, limit: 2

--- a/db/migrate/20160123214252_create_contest_supervisors.rb
+++ b/db/migrate/20160123214252_create_contest_supervisors.rb
@@ -1,4 +1,4 @@
-class CreateContestSupervisors < ActiveRecord::Migration
+class CreateContestSupervisors < ActiveRecord::Migration[4.2]
   def change
     create_table :contest_supervisors do |t|
       t.integer :contest_id

--- a/db/migrate/20160124011422_add_year_and_supervised_by_to_contest_relations.rb
+++ b/db/migrate/20160124011422_add_year_and_supervised_by_to_contest_relations.rb
@@ -1,4 +1,4 @@
-class AddYearAndSupervisedByToContestRelations < ActiveRecord::Migration
+class AddYearAndSupervisedByToContestRelations < ActiveRecord::Migration[4.2]
   def change
     add_column :contest_relations, :school_year, :integer
     add_column :contest_relations, :supervisor_id, :integer

--- a/db/migrate/20160124011836_fill_in_year_for_contest_relations.rb
+++ b/db/migrate/20160124011836_fill_in_year_for_contest_relations.rb
@@ -1,4 +1,4 @@
-class FillInYearForContestRelations < ActiveRecord::Migration
+class FillInYearForContestRelations < ActiveRecord::Migration[4.2]
   def up
     ContestRelation.all.each do |relation|
       year_level = relation.user.estimated_year_level(relation.contest.end_time)

--- a/db/migrate/20160130235209_add_scheduled_time_and_checked_in_to_contest_tables.rb
+++ b/db/migrate/20160130235209_add_scheduled_time_and_checked_in_to_contest_tables.rb
@@ -1,4 +1,4 @@
-class AddScheduledTimeAndCheckedInToContestTables < ActiveRecord::Migration
+class AddScheduledTimeAndCheckedInToContestTables < ActiveRecord::Migration[4.2]
   def change
     add_column :contest_relations, :checked_in, :boolean, default: false
     add_column :contest_supervisors, :scheduled_start_time, :datetime

--- a/db/migrate/20160131000430_update_checked_in_field.rb
+++ b/db/migrate/20160131000430_update_checked_in_field.rb
@@ -1,4 +1,4 @@
-class UpdateCheckedInField < ActiveRecord::Migration
+class UpdateCheckedInField < ActiveRecord::Migration[4.2]
   def up
     ContestRelation.all.each do |relation|
       relation.checked_in = true if relation.started?

--- a/db/migrate/20200418113600_add_live_scoreboard_field.rb
+++ b/db/migrate/20200418113600_add_live_scoreboard_field.rb
@@ -1,4 +1,4 @@
-class AddLiveScoreboardField < ActiveRecord::Migration
+class AddLiveScoreboardField < ActiveRecord::Migration[4.2]
   def change
     add_column :contests, :live_scoreboard, :boolean, default: true
   end

--- a/db/migrate/20200418113601_add_offical_contestants.rb
+++ b/db/migrate/20200418113601_add_offical_contestants.rb
@@ -1,4 +1,4 @@
-class AddOfficalContestants < ActiveRecord::Migration
+class AddOfficalContestants < ActiveRecord::Migration[4.2]
   def change
     add_column :contests, :only_rank_official_contestants, :boolean, default: false
   end

--- a/db/migrate/20230225054132_add_language_id_to_evaluators.rb
+++ b/db/migrate/20230225054132_add_language_id_to_evaluators.rb
@@ -1,4 +1,4 @@
-class AddLanguageIdToEvaluators < ActiveRecord::Migration
+class AddLanguageIdToEvaluators < ActiveRecord::Migration[4.2]
   def change
     add_column :evaluators, :language_id, :integer
   end

--- a/db/migrate/20250318053450_rename_setting_mailer_username_to_email.rb
+++ b/db/migrate/20250318053450_rename_setting_mailer_username_to_email.rb
@@ -1,4 +1,4 @@
-class RenameSettingMailerUsernameToEmail < ActiveRecord::Migration
+class RenameSettingMailerUsernameToEmail < ActiveRecord::Migration[4.2]
   # this migration can be deleted after deploying
 
   def up


### PR DESCRIPTION
Rails 5.1 requires this, and it's available since 5.0 so we can just
roll with it now.

https://github.com/rails/rails/blob/434c8dc96759d4eca36ca05865b6321c54a2a90b/activerecord/lib/active_record/migration/compatibility.rb#L105-L112
https://github.com/rails/rails/blob/434c8dc96759d4eca36ca05865b6321c54a2a90b/activerecord/lib/active_record/migration/compatibility.rb#L6-L93
https://www.bigbinary.com/blog/migrations-are-versioned-in-rails-5
https://github.com/rails/rails/pull/21538