### PR TITLE
Add puma to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,3 +99,5 @@ gem "uglifier", ">=1.0.3"
 gem "mini_racer", "~> 0.4.0"
 gem "yui-compressor"
 # end
+
+gem "puma", "~> 6.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,8 @@ GEM
       ttfunk (~> 1.5)
     psych (2.0.17)
     public_suffix (4.0.7)
+    puma (6.6.0)
+      nio4r (~> 2.0)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     pygments.rb (2.3.1)
@@ -408,6 +410,7 @@ DEPENDENCIES
   pg
   prawn
   psych (~> 2.0.2)
+  puma (~> 6.6)
   pundit (~> 1.1.0)
   pygments.rb (~> 2.0)
   qless!


### PR DESCRIPTION
We can probably switch from nginx-passenger to nginx + puma in
production, which means a few good things!

1. We'd be back to the rails default (since 5.0)
2. We'd run the same web server in dev and in prod (currently thin vs
   passenger)
3. We get the easy of maintenance and running of puma in production (vs
   passenger requiring all sorts of socket nonsense, etc)