### PR TITLE
Update install scripts for Ubuntu 24.04

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -59,7 +59,7 @@ class Language < ApplicationRecord
   # for the selection dropdown
   def self.grouped_submission_options
     current = ["c++", "c", "python", "csharp", "java", "javascript", "haskell", "ruby"] # language group identifiers, order is preserved
-    other = ["c++14", "c99", "pypy3"] # language identifiers, ordered by language name
+    other = ["c++14", "c99", "pypy3.11"] # language identifiers, ordered by language name
     current_langs = LanguageGroup.where(identifier: current).preload(:current_language).map(&:current_language)
     current_options = current_langs.sort_by { |lang| current.index(lang.group.identifier) }.map { |lang| [lang.name, lang.id] }
     other_options = Language.where(identifier: other).order(:name).pluck(:name, :id)

--- a/app/services/isolate.rb
+++ b/app/services/isolate.rb
@@ -3,7 +3,7 @@ require "open3"
 class Isolate
   private
 
-  RESOURCE_OPTIONS = {time: "-t", wall_time: "-w", extra_time: "-x", mem: "-m", stack: "-k", processes: "-p", meta: "-M", stderr: "-r", stdin: "-i", stdout: "-o", cg: "--cg", cg_timing: "--cg-timing", cg_mem: "--cg-mem=", inherit_fds: "--inherit-fds"} # TODO: :quota
+  RESOURCE_OPTIONS = {time: "-t", wall_time: "-w", extra_time: "-x", mem: "-m", stack: "-k", processes: "-p", meta: "-M", stderr: "-r", stdin: "-i", stdout: "-o", cg: "--cg", cg_timing: "--cg-timing", cg_mem: "--cg-mem=", inherit_fds: "--inherit-fds", open_files: "--open-files="} # TODO: :quota
   CONFIG = YAML.load_file(File.expand_path("config/isolate.yml", Rails.root)).symbolize_keys
   META = {"time" => :to_f, "time-wall" => :to_f, "max-rss" => :to_i, "csw-voluntary" => :to_i, "csw-forced" => :to_i, "killed" => :to_i, "cg-mem" => :to_i, "exitsig" => :to_i, "exitcode" => :to_i}
 
@@ -238,8 +238,9 @@ EOF
       "lib" => [], # core libraries
       "lib64" => [], # 64-bit libraries
       "usr" => [], # general binaries, includes and libraries
-      "opt" => [], # for ghc from ppa:hvr/ghc
-      "etc" => []
+      "opt" => [], # for ghc
+      "etc" => [],
+      "var/lib/ghc" => [], # for ghc
       # 'etc/alternatives' => [], # required for many symbolic links to work
     }.map do |dir, opt|
       fullpath = File.expand_path(dir, isolate_root)

--- a/app/workers/judge_submission_worker.rb
+++ b/app/workers/judge_submission_worker.rb
@@ -176,7 +176,7 @@ class JudgeSubmissionWorker < ApplicationWorker
   end
 
   def compile!(source, language, output)
-    result = language.compile(box, source, output, mem: 393216, wall_time: 60)
+    result = language.compile(box, source, output, mem: 393216, wall_time: 60, open_files: 128)
     FileUtils.copy(box.expand_path(output), File.expand_path(output, tmpdir)) if result["stat"] == 0
     result
   ensure

--- a/db/languages.yml
+++ b/db/languages.yml
@@ -20,7 +20,7 @@ c++:
       name: "C++03"
       compiler: g++
       compiler_command: "%{compiler} --version | head -n 1 1>&2 && %{compiler} -std=gnu++03 -O2 -o %{output} %{source} -lm"
-    c++11:
+    c++11: # deprecated
       name: "C++11"
       compiler: g++
       compiler_command: "%{compiler} --version | head -n 1 1>&2 && %{compiler} -std=gnu++11 -O2 -o %{output} %{source} -lm"
@@ -85,7 +85,7 @@ haskell:
   extension: .hs
   source_filename: program
   exe_extension: .exe
-  processes: 1
+  processes: 2
   variants:
     haskell2010:
       name: "Haskell 2010"
@@ -97,7 +97,7 @@ python:
   lexer: python
   compiled: no
   interpreted: yes
-  current: python3.8
+  current: python3.13
   extension: .py
   source_filename: program
   processes: 1
@@ -110,11 +110,17 @@ python:
     python3.4: # deprecated
       name: "Python 3.4"
       interpreter: /usr/bin/python3.4
-    python3.8:
+    python3.8: # deprecated
       name: "Python 3.8"
       interpreter: /usr/bin/python3.8
-    pypy3:
-      name: "Python 3.6 (PyPy 7.3)"
+    python3.13:
+      name: "Python 3.13"
+      interpreter: /usr/bin/python3.13
+    pypy3.6: # deprecated
+      name: "Python 3.6 (PyPy 7.3.7)"
+      interpreter: /usr/bin/pypy3
+    pypy3.11:
+      name: "Python 3.11 (PyPy 7.3.19)"
       interpreter: /usr/bin/pypy3
 
 ruby:
@@ -122,46 +128,59 @@ ruby:
   lexer: ruby
   compiled: no
   interpreted: yes
-  current: ruby2.2
+  current: ruby3.2
   extension: .rb
   source_filename: program
-  processes: 2 # ruby seems to have an extra process
   interpreter_command: "%{interpreter} %{source}"
   compiler_command: "%{interpreter} -c %{source}"
   variants:
-    ruby2.2:
+    ruby2.2: # deprecated
       name: "Ruby 2.2"
       interpreter: /usr/bin/ruby2.2
+      processes: 2 # ruby2.2 seems to have an extra process
+    ruby3.2:
+      name: "Ruby 3.2"
+      interpreter: /usr/bin/ruby
+      processes: 1
 
 javascript:
   name: JavaScript
   lexer: javascript
   compiled: no
   interpreted: yes
-  current: v8_8
+  current: v8_14
   extension: .js
   source_filename: program
   interpreter_command: "%{interpreter} %{source}"
   variants:
-    v8_8:
+    v8_8: # deprecated
       name: "JavaScript (V8 8.1)"
       interpreter: /usr/local/bin/d8
       processes: 9
+    v8_14:
+      name: "JavaScript (V8 14.0)"
+      interpreter: /usr/local/bin/d8
+      processes: 4
 
 csharp:
   name: "C#"
   lexer: csharp
   compiled: yes
   interpreted: yes
-  current: csharp8
+  current: csharp12
   extension: .cs
   source_filename: program
   exe_extension: .exe
-  processes: 5
+  processes: 9
   interpreter: /usr/local/bin/dotnet-exec # custom shell script
   variants:
     csharp8:
-      name: "C# 8.0"
+      name: "C# 8.0" # deprecated
       compiler: dotnet-csc # custom shell script (also prints SDK version number)
       compiler_command: "%{compiler} %{source} -optimize+ -out:%{output} -langversion:8.0 -nologo"
+      interpreter_command: "%{interpreter} %{source}"
+    csharp12:
+      name: "C# 12.0"
+      compiler: dotnet-csc # custom shell script (also prints SDK version number)
+      compiler_command: "%{compiler} %{source} -optimize+ -out:%{output} -langversion:12.0 -nologo"
       interpreter_command: "%{interpreter} %{source}"

--- a/script/install/cgroup.bash
+++ b/script/install/cgroup.bash
@@ -5,6 +5,6 @@
 source "`dirname $0`/../install.cfg"
 
 if $ISOLATE_CGROUPS; then
-  apt-get install cgroup-bin libcgroup1
+  apt-get install cgroup-tools libcgroup2
 fi
 

--- a/script/install/debootstrap.bash
+++ b/script/install/debootstrap.bash
@@ -17,7 +17,7 @@ do
     esac
 done
 
-SUITE=xenial
+SUITE=noble
 
 
 new_debootstrap=false
@@ -61,8 +61,8 @@ chroot "$ISOLATE_ROOT" apt-get install software-properties-common # provides add
 
 [ -z "$CI" ] && { # if not in CI
   # python ppa
-  if ! chroot "$ISOLATE_ROOT" apt-cache show python3.4 &>/dev/null ||
-      ! chroot "$ISOLATE_ROOT" apt-cache show python3.8 &>/dev/null; then
+  if ! chroot "$ISOLATE_ROOT" apt-cache show python3.8 &>/dev/null ||
+      ! chroot "$ISOLATE_ROOT" apt-cache show python3.13 &>/dev/null; then
     echo "$chroot_cmd add-apt-repository ppa:deadsnakes/ppa -y"
     chroot "$ISOLATE_ROOT" add-apt-repository ppa:deadsnakes/ppa -y
   fi
@@ -70,10 +70,6 @@ chroot "$ISOLATE_ROOT" apt-get install software-properties-common # provides add
   # pypy ppa
   echo "$chroot_cmd add-apt-repository ppa:pypy/ppa -y"
   chroot "$ISOLATE_ROOT" add-apt-repository ppa:pypy/ppa -y
-
-  # ruby ppa
-  echo "$chroot_cmd add-apt-repository ppa:brightbox/ruby-ng -y"
-  chroot "$ISOLATE_ROOT" add-apt-repository ppa:brightbox/ruby-ng -y
 
   echo "$chroot_cmd apt-get update"
   chroot "$ISOLATE_ROOT" apt-get update
@@ -92,18 +88,9 @@ echo "$chroot_install ruby"
 chroot "$ISOLATE_ROOT" apt-get install ruby # Ruby (ruby)
 
 [ -z "$CI" ] && { # if not in CI
-  # add haskell ppa
-  echo "$chroot_cmd add-apt-repository ppa:hvr/ghc -y"
-  chroot "$ISOLATE_ROOT" add-apt-repository ppa:hvr/ghc -y
 
-  echo "$chroot_cmd apt-get update"
-  chroot "$ISOLATE_ROOT" apt-get update
-
-  echo "$chroot_install ghc-8.8.2"
-  chroot "$ISOLATE_ROOT" apt-get install ghc-8.8.2 # Haskell (ghc)
-
-  echo "$chroot_cmd update-alternatives --install /usr/bin/ghc ghc /opt/ghc/8.8.2/bin/ghc 75"
-  chroot "$ISOLATE_ROOT" update-alternatives --install /usr/bin/ghc ghc /opt/ghc/8.8.2/bin/ghc 75
+  echo "$chroot_install ghc"
+  chroot "$ISOLATE_ROOT" apt-get install ghc # Haskell (ghc)
 
   # Note: Running ghc requires /proc to be mounted. The isolate command mounts
   # it, but it might not be mounted if running ghc manually in the chroot.
@@ -130,22 +117,16 @@ chroot "$ISOLATE_ROOT" apt-get install ruby # Ruby (ruby)
 
 [ -z "$CI" ] && { # if not in CI
 
-  # echo "$chroot_install python"
-  # chroot "$ISOLATE_ROOT" apt-get install python # Python 2 (deprecated)
-  echo "$chroot_install python3.4"
-  chroot "$ISOLATE_ROOT" apt-get install python3.4 # Python 3.4
   echo "$chroot_install python3.8"
   chroot "$ISOLATE_ROOT" apt-get install python3.8 # Python 3.8
+  echo "$chroot_install python3.13"
+  chroot "$ISOLATE_ROOT" apt-get install python3.13 # Python 3.13
   # note: when updating these Python versions, also update the check for adding the PPA above
 
   # PyPy
   # https://www.pypy.org
   echo "$chroot_install pypy3"
   chroot "$ISOLATE_ROOT" apt-get install pypy3
-
-
-  echo "$chroot_install ruby2.2"
-  chroot "$ISOLATE_ROOT" apt-get install ruby2.2
 
 }
 

--- a/script/install/dotnet.bash
+++ b/script/install/dotnet.bash
@@ -16,9 +16,9 @@ chroot "$ISOLATE_ROOT" add-apt-repository universe
 chroot "$ISOLATE_ROOT" apt-get install -y apt-transport-https
 chroot "$ISOLATE_ROOT" apt-get update
 
-: Installing dotnet 3.1
+: Installing dotnet 8.0
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
-chroot "$ISOLATE_ROOT" apt-get install -y dotnet-sdk-3.1
+chroot "$ISOLATE_ROOT" apt-get install -y dotnet-sdk-8.0
 
 : Creating runtime config file
 # The dotnet command requires executables to have a corresponding file

--- a/script/install/dotnet/dotnet-csc
+++ b/script/install/dotnet/dotnet-csc
@@ -4,5 +4,5 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 VERSION=$(dotnet --version)
 echo ".NET Core SDK $VERSION" 1>&2
 # [dotnet] [csc] -reference:[stdlib] [...passed in args...]
-dotnet "/usr/share/dotnet/sdk/$VERSION/Roslyn/bincore/csc.dll" \
-  -reference:"/usr/share/dotnet/sdk/$VERSION/ref/netstandard.dll" "$@" 1>&2
+dotnet "/usr/lib/dotnet/sdk/$VERSION/Roslyn/bincore/csc.dll" \
+  -reference:"/usr/lib/dotnet/sdk/$VERSION/ref/netstandard.dll" "$@" 1>&2

--- a/script/install/rbenv.bash
+++ b/script/install/rbenv.bash
@@ -16,12 +16,12 @@ rbenv --version &> /dev/null || {
   cmd="sudo apt-get install autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev"
   echo "$ $cmd"
   $cmd || exit 1
-  # as suggested, try installing libgdbm5, if it is not available try with libgdbm3
+  # as suggested, try installing libgdbm6, if it is not available try with libgdbm5
   # (it should have been installed as a dependency of libgdbm-dev anyway)
-  cmd="sudo apt-get install libgdbm5"
+  cmd="sudo apt-get install libgdbm6"
   echo "$ $cmd"
   $cmd || {
-    cmd="sudo apt-get install libgdbm3"
+    cmd="sudo apt-get install libgdbm5"
     echo "$ $cmd"
     $cmd || exit 1
   }

--- a/script/install/redis.bash
+++ b/script/install/redis.bash
@@ -19,9 +19,7 @@ redis-server --version 2>/dev/null | bash script/extract_version.bash | bash scr
   apt-get install chkconfig
 
   # install redis
-  # version temporarily locked to 7, because 8.0+ don't compile on Ubuntu 16.04 / gcc 5.4.0
-  # TODO: once that issue is fixed, "--version ..." can be removed to switch back to "stable"
-  bash "`dirname $0`/redis-installer.bash" --version 7.4.4
+  bash "`dirname $0`/redis-installer.bash"
   result=$?
 
   if [[ "$result" -eq 0 ]] ; then

--- a/script/install/v8.bash
+++ b/script/install/v8.bash
@@ -8,9 +8,9 @@ echo
 set -x
 
 : Installing dependencies
-sudo apt-get install python -y
 sudo apt-get install git -y
 sudo apt-get install wget -y
+sudo apt-get install ninja-build -y
 
 : Making temporary directory
 build="$HOME/v8-build"


### PR DESCRIPTION
We're looking to switch the server to Ubuntu 24.04 (currently on Ubuntu 16.04). This shouldn't be merged until we're ready to do, but I'm opening this now if anyone wants to review.

Have tested that all current languages work. Note that any deprecated versions (e.g. Python 3.8), will not currently be available for submission/rejudging.

Note that existing custom evaluators that were previously using Ruby 2.2 (through `#!/usr/bin/env ruby`) will now use Ruby 3.2.3 instead; I tested a few and they worked fine. Evaluators that were using "Python 3.6 (PyPy 7.3.7)" as the selected language should also still work, though they'll actually be using "Python 3.11 (PyPy 7.3.19)".

Language changes:
* Python 3.8 > Python 3.13
* Python 3.6 (PyPy 7.3.7) -> Python 3.11 (PyPy 7.3.19)
* Ruby 2.2 > Ruby 3.2
* C# 8.0 (.NET 3.1) > C# 12.0 ( .NET 8.0)
* (Haskell 2010) ghc 8.8.2 > ghc 9.4.7
* (JavaScript) V8 8.1 > V8 14.0

I haven't touched C++ for now but it should be trivial to upgrade to GCC 14.