### PR TITLE
Replace calls to #table_exists? with #data_source_exists?

### DIFF
--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -8,7 +8,7 @@ def email_address_with_name(address, name)
   end.to_s
 end
 
-if ActiveRecord::Base.connection.table_exists?(Setting.table_name)
+if ActiveRecord::Base.connection.data_source_exists?(Setting.table_name)
   email_setting = Setting.find_by_key("system/mailer/email")
   ActionMailer::Base.smtp_settings[:user_name] = email_setting&.value
   ActionMailer::Base.smtp_settings[:password] = Setting.find_by_key("system/mailer/password")&.value

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -8,7 +8,7 @@ NZTrain::Application.config.secret_token = "9c912a91a69a2b65a0de03c7c96f83c38b90
 
 # if a setting is stored in database, use that secret token instead (because that token is not checked in to the git repository)
 # only appears to affect cookie stored sessions (no apparent effect on database stored sessions)
-if ActiveRecord::Base.connection.table_exists?(Setting.table_name) && Setting.exists?(key: "sessions/secret_token")
+if ActiveRecord::Base.connection.data_source_exists?(Setting.table_name) && Setting.exists?(key: "sessions/secret_token")
   token = Setting.find_by_key("sessions/secret_token").value
   NZTrain::Application.config.secret_token = token if token && !token.empty?
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,6 @@
 Sentry.init do |config|
   # TODO: Migrate to the env var SENTRY_DSN or to secrets once we have a good method for managing these
-  if ActiveRecord::Base.connection.table_exists?(Setting.table_name) && Setting.exists?(key: "sentry_dsn")
+  if ActiveRecord::Base.connection.data_source_exists?(Setting.table_name) && Setting.exists?(key: "sentry_dsn")
     dsn = Setting.find_by_key("sentry_dsn")&.value
     config.dsn = dsn if dsn.present?
   end


### PR DESCRIPTION
table_exists? is removed in some future rails reason, but it's
deprecated now and very noisy now, so let's stop using it.