### PR TITLE
Productise the puma config further

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,4 @@ gem "yui-compressor"
 # end
 
 gem "puma", "~> 6.6"
+gem "sd_notify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,6 +329,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (1.3.0)
     rusage (0.2.0)
+    sd_notify (0.1.1)
     sentry-rails (5.26.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.26.0)
@@ -458,6 +459,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   ruby-duration
   rubyzip (= 1.3.0)
+  sd_notify
   sentry-rails
   simple-navigation (= 3.11.0)
   simple_form (= 3.3.1)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,36 +1,30 @@
+# Puma configuration file
+# https://github.com/puma/puma/blob/master/examples/config.rb
+
 # Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum, this matches the default thread size of Active Record.
-#
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 5).to_i
+# The `threads` method sets the minimum and maximum number of threads to use.
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests, default is 3000.
-#
+# Specifies the `port` that Puma will listen on
 port ENV.fetch("PORT", 3000)
 
-# Specifies the `environment` that Puma will run in.
-#
-environment ENV.fetch("RAILS_ENV") { "development" }
+# Specifies the `environment` that Puma will run in
+environment ENV.fetch("RAILS_ENV", "development")
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked webserver processes. If using threads and workers together
+# Specifies the `pidfile` that Puma will use
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
+
+# Specifies the number of `workers` to boot in clustered mode
+# Workers are forked web server processes. If using threads and workers together,
 # the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY", 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory. If you use this option
-# you need to make sure to reconnect any threads in the `on_worker_boot`
-# block.
-#
-# preload_app!
+# process behavior so workers use less memory.
+preload_app!
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -38,10 +32,17 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # option you will want to use this block to reconnect to any threads
 # or connections that may have been created at application boot, Ruby
 # cannot share connections between processes.
-#
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
-# Allow puma to be restarted by `rails restart` command.
+# Allow puma to be restarted by `rails restart` command
 plugin :tmp_restart
+
+# Enable systemd notify support
+if ENV["NOTIFY_SOCKET"]
+  on_booted do
+    require "sd_notify"
+    SdNotify.ready
+  end
+end


### PR DESCRIPTION
Update the puma config for actually running in production, based on the
recommended unit file from the Puma repo. Add sd_notify to the Gemfile
to so that puma can use systemd watchdog to make sure it's running
healthy and happy.