### PR TITLE
Allow overriding the deploy branch during a cap deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,6 +5,7 @@ set :repo_url, "git@github.com:NZOI/nztrain.git"
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+set :branch, ENV.fetch("DEPLOY_BRANCH", "master")
 
 # Default deploy_to directory is /var/www/my_app_name
 # set :deploy_to, "/var/www/my_app_name"


### PR DESCRIPTION
By specifying DEPLOY_BRANCH=<branch_name> a different branch will be
deployed to the specified environment, instead of the default master.