### PR TITLE
Fix rounding issues that appeared with subtask scoring

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,7 +44,9 @@ module ApplicationHelper
     if score.nil?
       text = weighting.nil? || options[:size] == :compact ? "-" : "-&nbsp;/#{weighting}"
     else
-      score = score.to_i
+      # The + 1e-6 is necessary to avoid the case where floating point imprecision results in a score
+      # like 57.9999999 which would be truncated to 57 instead of rounded to 58.
+      score = (score + 1e-6).to_i
       text = score.to_s
       unless options[:size] == :compact
         text += if weighting.nil?

--- a/app/models/contest_score.rb
+++ b/app/models/contest_score.rb
@@ -23,7 +23,8 @@ class ContestScore < ApplicationRecord
         weighting = contest.problem_set.problem_associations.find_by(problem_id: problem_id).weighting
         unweighted_score, self.attempt, submission = ScoringMethods.score_problem_submissions(problem, submissions) # Does correct subtask or maximum scoring
         # Set score to zero if we encounter something unexpected
-        self.score = (unweighted_score.nil? || weighting.nil? ? 0 : (unweighted_score * weighting).to_i)
+        # Add +1e-6 to avoid floating point imprecision issues/rounding weirdness
+        self.score = (unweighted_score.nil? || weighting.nil? ? 0 : (unweighted_score * weighting + 1e-6).to_i)
         self.submission_id = submission.id
         save
       end

--- a/app/models/user_problem_relation.rb
+++ b/app/models/user_problem_relation.rb
@@ -23,7 +23,8 @@ class UserProblemRelation < ApplicationRecord
       else
         unweighted_ranked_score, self.ranked_submission = unweighted_score, submission
       end
-      self.ranked_score = unweighted_ranked_score.nil? ? nil : (100 * unweighted_ranked_score).to_i
+      # +1e-6 to avoid floating point imprecision issues
+      self.ranked_score = unweighted_ranked_score.nil? ? nil : (100 * unweighted_ranked_score + 1e-6).to_i
 
       save
     end


### PR DESCRIPTION
This fix should remove weird rounding issues that cropped up with subtask scoring.

For example, a score that should be 58 would sometimes be displayed as 57 since due to floating point imprecision it was stored as 57.99999999 before getting rounded down.

This pull request should remove such issues while minimising any other visible changes (so most scores wouldn't change at all)