### PR TITLE
Return database connections to the pool after each qless job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,18 @@ namespace :qless do
 
     Qless::Workers::ForkingWorker.send(:include, ActiveRecordReconnect)
 
+    module ActiveRecordReconnectJob
+      def around_perform(job)
+        ActiveRecord::Base.connection_pool.with_connection do
+          super(job)
+        end
+      end
+    end
+
+    Qless::Workers::BaseWorker.class_eval do
+      include ActiveRecordReconnectJob
+    end
+
     # The only required option is QUEUES; the
     # rest have reasonable defaults.
     queues = %w[judge queue stalejudge importer].map { |name| $qless.queues[name] }


### PR DESCRIPTION
This fixes an issue where workers could fail to judge submissions if the database connection was dropped (e.g. because postgresql was restarted).

https://discord.com/channels/670126531489824788/678154623571329025/1485894172748550185